### PR TITLE
Minimal required change to remove marketplace/resources (spaces) in UI.

### DIFF
--- a/src/components/layout/CommunityPanel.tsx
+++ b/src/components/layout/CommunityPanel.tsx
@@ -234,11 +234,13 @@ export function CommunityPanel({ communityId, selectedChannel, selectedSpace, on
       <ScrollArea className="flex-1 min-h-0">
         <div className="p-2 space-y-4 w-full">
           {/* Spaces Navigator - Marketplace and Resources */}
+          <div className="hidden">
           <SpacesNavigator
             communityId={communityId}
             selectedSpace={selectedSpace || null}
             onSelectSpace={(spaceId) => onSelectSpace?.(spaceId)}
           />
+          </div>
 
           {/* Channel Organizer */}
           <ChannelOrganizer


### PR DESCRIPTION
Per the current MVP milestone, the spaces section (Marketplace/Resources) should not be included. This change hides the controls from the UI for now to satisfy this requirement.

Before:
<img width="286" height="224" alt="image" src="https://github.com/user-attachments/assets/eef5f6f3-511f-45a3-8855-aeab3a3a1efd" />

After:
<img width="277" height="120" alt="image" src="https://github.com/user-attachments/assets/be4ef106-f096-4be0-9441-427f435f2f7b" />
