### PR TITLE
Add image gallery for chat images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^6.26.2",
         "react-virtuoso": "^4.13.0",
+        "react-zoom-pan-pinch": "^3.7.0",
         "recharts": "^2.12.7",
         "remark-gfm": "^4.0.1",
         "sonner": "^1.5.0",
@@ -7770,6 +7771,20 @@
       "peerDependencies": {
         "react": ">=16 || >=17 || >= 18 || >= 19",
         "react-dom": ">=16 || >=17 || >= 18 || >=19"
+      }
+    },
+    "node_modules/react-zoom-pan-pinch": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-3.7.0.tgz",
+      "integrity": "sha512-UmReVZ0TxlKzxSbYiAj+LeGRW8s8LraAFTXRAxzMYnNRgGPsxCudwZKVkjvGmjtx7SW/hZamt69NUmGf4xrkXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
     "react-virtuoso": "^4.13.0",
+    "react-zoom-pan-pinch": "^3.7.0",
     "recharts": "^2.12.7",
     "remark-gfm": "^4.0.1",
     "sonner": "^1.5.0",

--- a/src/components/ChatImage.tsx
+++ b/src/components/ChatImage.tsx
@@ -1,0 +1,145 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Loader2, ZoomIn } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface ChatImageProps {
+  src: string;
+  alt: string;
+  className?: string;
+  onClick?: () => void;
+  onError?: (e: React.SyntheticEvent<HTMLImageElement, Event>) => void;
+}
+
+export function ChatImage({ src, alt, className, onClick, onError }: ChatImageProps) {
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const imgRef = useRef<HTMLImageElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleLoad = () => {
+    setIsLoading(false);
+    setHasError(false);
+  };
+
+  const handleError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
+    setIsLoading(false);
+    setHasError(true);
+    onError?.(e);
+  };
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (!hasError && !isLoading) {
+      e.stopPropagation();
+      setIsExpanded(!isExpanded);
+      if (!isExpanded) {
+        // Only trigger the gallery click when expanding
+        onClick?.();
+      }
+    }
+  };
+
+  // Close expanded view when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node) && isExpanded) {
+        setIsExpanded(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isExpanded]);
+
+  return (
+    <>
+      {/* Preview thumbnail */}
+      <div 
+        ref={containerRef}
+        className={cn(
+          "relative inline-block cursor-pointer group overflow-hidden rounded-lg max-w-xs transition-all duration-300 hover:shadow-lg hover:scale-105",
+          isExpanded ? "fixed inset-0 z-[99999] bg-black/90 backdrop-blur-sm rounded-none max-w-none max-h-none m-auto" : "",
+          className
+        )}
+        onClick={handleClick}
+        style={
+          isExpanded 
+            ? {} 
+            : { transformOrigin: 'center center' }
+        }
+      >
+        {isLoading && (
+          <div className="absolute inset-0 flex items-center justify-center bg-muted/20">
+            <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+          </div>
+        )}
+        
+        {hasError ? (
+          <div className="absolute inset-0 flex items-center justify-center bg-muted/20 rounded-lg">
+            <div className="text-center">
+              <div className="text-2xl mb-1">🖼️</div>
+              <p className="text-xs text-muted-foreground">Failed to load</p>
+            </div>
+          </div>
+        ) : (
+          <img
+            ref={imgRef}
+            src={src}
+            alt={alt}
+            className={cn(
+              "w-full h-48 object-cover transition-all duration-300",
+              isExpanded 
+                ? "max-w-[90vw] max-h-[90vh] w-auto h-auto object-contain" 
+                : "hover:opacity-90"
+            )}
+            onLoad={handleLoad}
+            onError={handleError}
+            loading="lazy"
+            style={
+              isExpanded 
+                ? { transform: 'scale(1)' }
+                : { transformOrigin: 'center center' }
+            }
+          />
+        )}
+        
+        {/* Subtle hover overlay - only for preview state */}
+        {!isExpanded && (
+          <div className="absolute inset-0 bg-black/0 opacity-0 group-hover:opacity-10 transition-opacity duration-200 pointer-events-none rounded-lg" />
+        )}
+        
+        {/* Expand indicator */}
+        {!isExpanded && !hasError && !isLoading && (
+          <div className="absolute bottom-2 right-2 bg-black/60 rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity">
+            <ZoomIn className="w-3 h-3 text-white" />
+          </div>
+        )}
+        
+        {/* Close button for expanded state */}
+        {isExpanded && (
+          <button
+            className="absolute top-4 right-4 bg-black/60 hover:bg-black/80 text-white rounded-full w-8 h-8 flex items-center justify-center transition-colors z-[100000]"
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsExpanded(false);
+            }}
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      {/* Backdrop for expanded state */}
+      {isExpanded && (
+        <div 
+          className="fixed inset-0 bg-black/50 z-[99998] transition-opacity duration-300"
+          onClick={() => setIsExpanded(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/ChatImage.tsx
+++ b/src/components/ChatImage.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useRef, useEffect } from 'react';
-import { Loader2, ZoomIn } from 'lucide-react';
+import React, { useState, useRef } from 'react';
+import { Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface ChatImageProps {
@@ -13,9 +13,7 @@ interface ChatImageProps {
 export function ChatImage({ src, alt, className, onClick, onError }: ChatImageProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
-  const [isExpanded, setIsExpanded] = useState(false);
   const imgRef = useRef<HTMLImageElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
 
   const handleLoad = () => {
     setIsLoading(false);
@@ -31,51 +29,26 @@ export function ChatImage({ src, alt, className, onClick, onError }: ChatImagePr
   const handleClick = (e: React.MouseEvent) => {
     if (!hasError && !isLoading) {
       e.stopPropagation();
-      setIsExpanded(!isExpanded);
-      if (!isExpanded) {
-        // Only trigger the gallery click when expanding
-        onClick?.();
-      }
+      onClick?.();
     }
   };
-
-  // Close expanded view when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node) && isExpanded) {
-        setIsExpanded(false);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [isExpanded]);
 
   return (
     <>
       {/* Preview thumbnail */}
-      <div 
-        ref={containerRef}
+      <div
         className={cn(
           "relative inline-block cursor-pointer group overflow-hidden rounded-lg max-w-xs transition-all duration-300 hover:shadow-lg hover:scale-105",
-          isExpanded ? "fixed inset-0 z-[99999] bg-black/90 backdrop-blur-sm rounded-none max-w-none max-h-none m-auto" : "",
           className
         )}
         onClick={handleClick}
-        style={
-          isExpanded 
-            ? {} 
-            : { transformOrigin: 'center center' }
-        }
       >
         {isLoading && (
           <div className="absolute inset-0 flex items-center justify-center bg-muted/20">
             <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
           </div>
         )}
-        
+
         {hasError ? (
           <div className="absolute inset-0 flex items-center justify-center bg-muted/20 rounded-lg">
             <div className="text-center">
@@ -88,58 +61,17 @@ export function ChatImage({ src, alt, className, onClick, onError }: ChatImagePr
             ref={imgRef}
             src={src}
             alt={alt}
-            className={cn(
-              "w-full h-48 object-cover transition-all duration-300",
-              isExpanded 
-                ? "max-w-[90vw] max-h-[90vh] w-auto h-auto object-contain" 
-                : "hover:opacity-90"
-            )}
+            className="w-full h-48 object-cover transition-all duration-300 hover:opacity-90"
             onLoad={handleLoad}
             onError={handleError}
             loading="lazy"
-            style={
-              isExpanded 
-                ? { transform: 'scale(1)' }
-                : { transformOrigin: 'center center' }
-            }
+            style={{ transformOrigin: 'center center' }}
           />
         )}
-        
-        {/* Subtle hover overlay - only for preview state */}
-        {!isExpanded && (
-          <div className="absolute inset-0 bg-black/0 opacity-0 group-hover:opacity-10 transition-opacity duration-200 pointer-events-none rounded-lg" />
-        )}
-        
-        {/* Expand indicator */}
-        {!isExpanded && !hasError && !isLoading && (
-          <div className="absolute bottom-2 right-2 bg-black/60 rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity">
-            <ZoomIn className="w-3 h-3 text-white" />
-          </div>
-        )}
-        
-        {/* Close button for expanded state */}
-        {isExpanded && (
-          <button
-            className="absolute top-4 right-4 bg-black/60 hover:bg-black/80 text-white rounded-full w-8 h-8 flex items-center justify-center transition-colors z-[100000]"
-            onClick={(e) => {
-              e.stopPropagation();
-              setIsExpanded(false);
-            }}
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18 6L6 18M6 6l12 12" />
-            </svg>
-          </button>
-        )}
-      </div>
 
-      {/* Backdrop for expanded state */}
-      {isExpanded && (
-        <div 
-          className="fixed inset-0 bg-black/50 z-[99998] transition-opacity duration-300"
-          onClick={() => setIsExpanded(false)}
-        />
-      )}
+        {/* Subtle hover overlay */}
+        <div className="absolute inset-0 bg-black/0 opacity-0 group-hover:opacity-10 transition-opacity duration-200 pointer-events-none rounded-lg" />
+      </div>
     </>
   );
 }

--- a/src/components/ImageGallery.tsx
+++ b/src/components/ImageGallery.tsx
@@ -234,7 +234,7 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
   return (
     <DialogPrimitive.Root open={isOpen} onOpenChange={onClose}>
       <ImageGalleryDialogContent
-        className="max-w-[100vw] max-h-[100vh] w-[100vw] h-[100vh] p-0 bg-background/85 border-0 md:max-w-[100vw] md:max-h-[100vh]"
+        className="p-0 bg-background/85 border-0"
         onKeyDown={handleKeyDown}
         style={{
           // Ensure the gallery covers the full viewport including safe areas on mobile
@@ -252,11 +252,11 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
             Image Gallery - Viewing image {currentIndex + 1} of {images.length}
           </DialogPrimitive.Title>
         </VisuallyHidden.Root>
-        <div className="relative w-full h-full flex items-center justify-center overflow-hidden" onClick={onClose}>
+        <div className="relative flex items-center justify-center overflow-hidden" onClick={onClose}>
           {/* Content container - this defines the boundaries for button positioning */}
           <div
             ref={contentRef}
-            className="relative w-full h-full flex items-center justify-center md:p-8 max-w-7xl mx-auto"
+            className="relative h-[95%] flex items-center justify-center md:p-8 2xl:max-w-[60vw] mx-auto"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Close button - positioned within content container */}

--- a/src/components/ImageGallery.tsx
+++ b/src/components/ImageGallery.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { ChevronLeft, ChevronRight, X, Download, ExternalLink, ZoomIn, ZoomOut, RotateCcw, Loader2 } from 'lucide-react';
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { Button } from '@/components/ui/button';
@@ -59,7 +59,10 @@ function ZoomControls() {
         variant="ghost"
         size="icon"
         className="text-white hover:bg-white/30 bg-transparent"
-        onClick={() => zoomIn()}
+        onClick={(e) => {
+          e.stopPropagation();
+          zoomIn();
+        }}
         title="Zoom in"
       >
         <ZoomIn className="h-4 w-4" />
@@ -68,7 +71,10 @@ function ZoomControls() {
         variant="ghost"
         size="icon"
         className="text-white hover:bg-white/30 bg-transparent"
-        onClick={() => zoomOut()}
+        onClick={(e) => {
+          e.stopPropagation();
+          zoomOut();
+        }}
         title="Zoom out"
       >
         <ZoomOut className="h-4 w-4" />
@@ -77,7 +83,10 @@ function ZoomControls() {
         variant="ghost"
         size="icon"
         className="text-white hover:bg-white/30 bg-transparent"
-        onClick={() => resetTransform()}
+        onClick={(e) => {
+          e.stopPropagation();
+          resetTransform();
+        }}
         title="Reset zoom"
       >
         <RotateCcw className="h-4 w-4" />
@@ -90,6 +99,24 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
   const [isDownloading, setIsDownloading] = useState(false);
   const { toast } = useToast();
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  // Handle clicks outside the main content container
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (contentRef.current && !contentRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen, onClose]);
 
   const goToPrevious = () => {
     setCurrentIndex((prev) => (prev === 0 ? images.length - 1 : prev - 1));
@@ -225,9 +252,13 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
             Image Gallery - Viewing image {currentIndex + 1} of {images.length}
           </DialogPrimitive.Title>
         </VisuallyHidden.Root>
-        <div className="relative w-full h-full flex items-center justify-center overflow-hidden">
+        <div className="relative w-full h-full flex items-center justify-center overflow-hidden" onClick={onClose}>
           {/* Content container - this defines the boundaries for button positioning */}
-          <div className="relative w-full h-full flex items-center justify-center md:p-8 max-w-7xl mx-auto">
+          <div
+            ref={contentRef}
+            className="relative w-full h-full flex items-center justify-center md:p-8 max-w-7xl mx-auto"
+            onClick={(e) => e.stopPropagation()}
+          >
             {/* Close button - positioned within content container */}
             <Button
               variant="ghost"
@@ -237,7 +268,10 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
                 // Account for mobile safe area and navigation
                 top: 'max(0.5rem, env(safe-area-inset-top, 0px))',
               }}
-              onClick={onClose}
+              onClick={(e) => {
+                e.stopPropagation();
+                onClose();
+              }}
             >
               <X className="h-5 w-5 sm:h-6 sm:w-6" />
             </Button>
@@ -254,7 +288,10 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
                 variant="ghost"
                 size="icon"
                 className="text-white hover:bg-white/20 bg-black/30"
-                onClick={handleDownload}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleDownload();
+                }}
                 disabled={isDownloading}
                 title={isDownloading ? "Downloading..." : "Download image"}
               >
@@ -268,7 +305,10 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
                 variant="ghost"
                 size="icon"
                 className="text-white hover:bg-white/20 bg-black/30"
-                onClick={handleOpenInNewTab}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleOpenInNewTab();
+                }}
                 title="Open in new tab"
               >
                 <ExternalLink className="h-4 w-4" />
@@ -282,7 +322,10 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
                   variant="ghost"
                   size="icon"
                   className="absolute left-2 sm:left-8 top-1/2 -translate-y-1/2 z-50 text-white hover:bg-white/20 bg-black/30"
-                  onClick={goToPrevious}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    goToPrevious();
+                  }}
                 >
                   <ChevronLeft className="h-6 w-6 sm:h-7 sm:w-7" />
                 </Button>
@@ -290,7 +333,10 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
                   variant="ghost"
                   size="icon"
                   className="absolute right-2 sm:right-8 top-1/2 -translate-y-1/2 z-50 text-white hover:bg-white/20 bg-black/30"
-                  onClick={goToNext}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    goToNext();
+                  }}
                 >
                   <ChevronRight className="h-6 w-6 sm:h-7 sm:w-7" />
                 </Button>
@@ -359,7 +405,10 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
                   {images.map((image, index) => (
                     <button
                       key={index}
-                      onClick={() => setCurrentIndex(index)}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setCurrentIndex(index);
+                      }}
                       className={`flex-shrink-0 w-12 h-12 sm:w-14 sm:h-14 rounded-lg overflow-hidden border-2 transition-all ${
                         index === currentIndex
                           ? 'border-white shadow-lg'

--- a/src/components/ImageGallery.tsx
+++ b/src/components/ImageGallery.tsx
@@ -58,7 +58,7 @@ function ZoomControls() {
       <Button
         variant="ghost"
         size="icon"
-        className="text-white hover:bg-white/30 bg-transparent"
+        className="text-white hover:bg-white/30 bg-transparent rounded-full"
         onClick={(e) => {
           e.stopPropagation();
           zoomIn();
@@ -70,7 +70,7 @@ function ZoomControls() {
       <Button
         variant="ghost"
         size="icon"
-        className="text-white hover:bg-white/30 bg-transparent"
+        className="text-white hover:bg-white/30 bg-transparent rounded-full"
         onClick={(e) => {
           e.stopPropagation();
           zoomOut();
@@ -82,7 +82,7 @@ function ZoomControls() {
       <Button
         variant="ghost"
         size="icon"
-        className="text-white hover:bg-white/30 bg-transparent"
+        className="text-white hover:bg-white/30 bg-transparent rounded-full"
         onClick={(e) => {
           e.stopPropagation();
           resetTransform();

--- a/src/components/ImageGallery.tsx
+++ b/src/components/ImageGallery.tsx
@@ -16,7 +16,7 @@ interface ImageGalleryProps {
 
 /**
  * ImageGallery component with pinch zoom functionality
- * 
+ *
  * Features:
  * - Pinch to zoom on touch devices
  * - Mouse wheel zoom on desktop
@@ -52,37 +52,37 @@ ImageGalleryDialogContent.displayName = "ImageGalleryDialogContent";
 // Zoom controls component that uses the useControls hook
 function ZoomControls() {
   const { zoomIn, zoomOut, resetTransform } = useControls();
-  
+
   return (
-    <div className="flex gap-1">
+    <>
       <Button
         variant="ghost"
         size="icon"
-        className="text-white hover:bg-white/20 bg-black/30"
+        className="text-white hover:bg-white/30 bg-transparent"
         onClick={() => zoomIn()}
         title="Zoom in"
       >
-        <ZoomIn className="h-4 w-4 md:h-5 md:w-5" />
+        <ZoomIn className="h-4 w-4" />
       </Button>
       <Button
         variant="ghost"
         size="icon"
-        className="text-white hover:bg-white/20 bg-black/30"
+        className="text-white hover:bg-white/30 bg-transparent"
         onClick={() => zoomOut()}
         title="Zoom out"
       >
-        <ZoomOut className="h-4 w-4 md:h-5 md:w-5" />
+        <ZoomOut className="h-4 w-4" />
       </Button>
       <Button
         variant="ghost"
         size="icon"
-        className="text-white hover:bg-white/20 bg-black/30"
+        className="text-white hover:bg-white/30 bg-transparent"
         onClick={() => resetTransform()}
         title="Reset zoom"
       >
-        <RotateCcw className="h-4 w-4 md:h-5 md:w-5" />
+        <RotateCcw className="h-4 w-4" />
       </Button>
-    </div>
+    </>
   );
 }
 
@@ -111,48 +111,48 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
 
   const handleDownload = async () => {
     if (isDownloading) return;
-    
+
     setIsDownloading(true);
-    
+
     try {
       const imageUrl = images[currentIndex];
       if (!imageUrl) {
         throw new Error('No image URL provided');
       }
-      
+
       // Extract filename from URL or create a default one
       const urlParts = imageUrl.split('/');
       const urlFilename = urlParts[urlParts.length - 1] || '';
-      
+
       // Remove query parameters first
       const cleanFilename = urlFilename.split('?')[0] || '';
-      
+
       // Check if the clean filename has a valid image extension
-      const hasExtension = cleanFilename.includes('.') && 
+      const hasExtension = cleanFilename.includes('.') &&
         cleanFilename.split('.').pop()?.match(/^(jpg|jpeg|png|gif|webp|svg)$/i) !== undefined;
-      
-      const filename = hasExtension 
-        ? cleanFilename 
+
+      const filename = hasExtension
+        ? cleanFilename
         : `chat-image-${currentIndex + 1}.jpg`;
-      
+
       // Try to fetch the image and download it as a blob (handles CORS better)
       try {
         const response = await fetch(imageUrl);
         if (!response.ok) throw new Error('Network response was not ok');
-        
+
         const blob = await response.blob();
         const blobUrl = URL.createObjectURL(blob);
-        
+
         const link = document.createElement('a');
         link.href = blobUrl;
         link.download = filename;
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);
-        
+
         // Clean up the blob URL
         URL.revokeObjectURL(blobUrl);
-        
+
         toast({
           title: 'Download started',
           description: `Downloading ${filename}`,
@@ -168,7 +168,7 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);
-        
+
         toast({
           title: 'Download started',
           description: `Downloading ${filename} (fallback method)`,
@@ -176,13 +176,13 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
       }
     } catch (error) {
       console.error('Download failed:', error);
-      
+
       toast({
         title: 'Download failed',
         description: 'Opening image in new tab instead',
         variant: 'destructive',
       });
-      
+
       // Final fallback: open in new tab
       window.open(images[currentIndex], '_blank', 'noopener,noreferrer');
     } finally {
@@ -206,7 +206,7 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
 
   return (
     <DialogPrimitive.Root open={isOpen} onOpenChange={onClose}>
-      <ImageGalleryDialogContent 
+      <ImageGalleryDialogContent
         className="max-w-[100vw] max-h-[100vh] w-[100vw] h-[100vh] p-0 bg-background/85 border-0 md:max-w-[100vw] md:max-h-[100vh]"
         onKeyDown={handleKeyDown}
         style={{
@@ -230,22 +230,24 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
           <Button
             variant="ghost"
             size="icon"
-            className="absolute top-2 md:top-4 right-2 md:right-4 z-50 text-white hover:bg-white/20 bg-black/30"
+            className="absolute top-2 sm:top-4 right-2 sm:right-4 z-50 text-white hover:bg-white/20 bg-black/30"
             style={{
               // Account for mobile safe area and navigation
               top: 'max(0.5rem, env(safe-area-inset-top, 0px))',
+              right: 'max(0.5rem, env(safe-area-inset-right, 0px))',
             }}
             onClick={onClose}
           >
-            <X className="h-5 w-5 md:h-6 md:w-6" />
+            <X className="h-5 w-5 sm:h-6 sm:w-6" />
           </Button>
 
           {/* Action buttons */}
-          <div 
-            className="absolute top-2 md:top-4 left-2 md:left-4 z-50 flex gap-2"
+          <div
+            className="absolute top-2 sm:top-4 left-2 sm:left-4 z-50 flex gap-2"
             style={{
               // Account for mobile safe area and navigation
               top: 'max(0.5rem, env(safe-area-inset-top, 0px))',
+              left: 'max(0.5rem, env(safe-area-inset-left, 0px))',
             }}
           >
             <Button
@@ -257,9 +259,9 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
               title={isDownloading ? "Downloading..." : "Download image"}
             >
               {isDownloading ? (
-                <Loader2 className="h-4 w-4 md:h-5 md:w-5 animate-spin" />
+                <Loader2 className="h-4 w-4 animate-spin" />
               ) : (
-                <Download className="h-4 w-4 md:h-5 md:w-5" />
+                <Download className="h-4 w-4" />
               )}
             </Button>
             <Button
@@ -269,7 +271,7 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
               onClick={handleOpenInNewTab}
               title="Open in new tab"
             >
-              <ExternalLink className="h-4 w-4 md:h-5 md:w-5" />
+              <ExternalLink className="h-4 w-4" />
             </Button>
           </div>
 
@@ -279,29 +281,29 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
               <Button
                 variant="ghost"
                 size="icon"
-                className="absolute left-2 md:left-4 top-1/2 -translate-y-1/2 z-50 text-white hover:bg-white/20 bg-black/30"
+                className="absolute left-2 sm:left-4 top-1/2 -translate-y-1/2 z-50 text-white hover:bg-white/20 bg-black/30"
                 onClick={goToPrevious}
               >
-                <ChevronLeft className="h-6 w-6 md:h-8 md:w-8" />
+                <ChevronLeft className="h-6 w-6 sm:h-7 sm:w-7" />
               </Button>
               <Button
                 variant="ghost"
                 size="icon"
-                className="absolute right-2 md:right-4 top-1/2 -translate-y-1/2 z-50 text-white hover:bg-white/20 bg-black/30"
+                className="absolute right-2 sm:right-4 top-1/2 -translate-y-1/2 z-50 text-white hover:bg-white/20 bg-black/30"
                 onClick={goToNext}
               >
-                <ChevronRight className="h-6 w-6 md:h-8 md:w-8" />
+                <ChevronRight className="h-6 w-6 sm:h-7 sm:w-7" />
               </Button>
             </>
           )}
 
           {/* Main image with zoom functionality */}
-          <div 
+          <div
             className="w-full h-full flex items-center justify-center p-4 md:p-8"
             style={{
-              // Account for mobile safe areas and navigation buttons
+              // Account for mobile safe areas, navigation buttons, and zoom controls
               paddingTop: 'max(4rem, calc(env(safe-area-inset-top, 0px) + 3rem))',
-              paddingBottom: 'max(6rem, calc(env(safe-area-inset-bottom, 0px) + 6rem))',
+              paddingBottom: 'max(8rem, calc(env(safe-area-inset-bottom, 0px) + 8rem))',
             }}
           >
             <TransformWrapper
@@ -311,7 +313,7 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
               wheel={{ step: 0.1 }}
               pinch={{ step: 5 }}
               doubleClick={{ mode: "toggle", step: 0.7 }}
-              panning={{ 
+              panning={{
                 velocityDisabled: true,
                 // Disable panning when not zoomed to allow navigation gestures
                 disabled: false
@@ -322,28 +324,13 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
               limitToBounds={true}
               centerZoomedOut={true}
             >
-              {/* Desktop zoom controls positioned absolutely within the transform wrapper */}
-              <div 
-                className="absolute top-2 md:top-4 right-16 md:right-20 z-50 hidden md:flex gap-1"
-                style={{
-                  // Account for mobile safe area and navigation
-                  top: 'max(0.5rem, env(safe-area-inset-top, 0px))',
-                }}
-              >
-                <ZoomControls />
+              {/* Zoom controls positioned under the image */}
+              <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-50">
+                <div className="bg-black/50 backdrop-blur-sm rounded-full p-1 flex gap-1">
+                  <ZoomControls />
+                </div>
               </div>
 
-              {/* Mobile zoom controls positioned at bottom */}
-              <div 
-                className="absolute bottom-20 left-1/2 -translate-x-1/2 z-50 md:hidden flex gap-1"
-                style={{
-                  // Account for mobile safe area
-                  bottom: 'max(5rem, calc(env(safe-area-inset-bottom, 0px) + 7rem))',
-                }}
-              >
-                <ZoomControls />
-              </div>
-              
               <TransformComponent
                 wrapperClass="!w-full !h-full"
                 contentClass="!w-full !h-full flex items-center justify-center"
@@ -361,28 +348,28 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
 
           {/* Image counter and thumbnail navigation */}
           {images.length > 1 && (
-            <div 
-              className="absolute bottom-4 left-1/2 -translate-x-1/2 z-50 flex flex-col items-center gap-2"
+            <div
+              className="absolute bottom-20 left-1/2 -translate-x-1/2 z-50 flex flex-col items-center gap-2"
               style={{
-                // Account for mobile safe area
-                bottom: 'max(1rem, calc(env(safe-area-inset-bottom, 0px) + 1rem))',
+                // Account for mobile safe area and zoom controls
+                bottom: 'max(5rem, calc(env(safe-area-inset-bottom, 0px) + 5rem))',
               }}
             >
               {/* Image counter */}
               <div className="bg-black/50 text-white px-3 py-1 rounded-full text-sm">
                 {currentIndex + 1} of {images.length}
               </div>
-              
+
               {/* Thumbnail navigation */}
-              <div className="flex gap-2 max-w-[calc(100vw-2rem)] overflow-x-auto px-2">
+              <div className="flex gap-2 max-w-[calc(100vw-4rem)] overflow-x-auto px-2">
                 <div className="flex gap-2 pb-2">
                   {images.map((image, index) => (
                     <button
                       key={index}
                       onClick={() => setCurrentIndex(index)}
-                      className={`flex-shrink-0 w-12 h-12 md:w-16 md:h-16 rounded-lg overflow-hidden border-2 transition-all ${
-                        index === currentIndex 
-                          ? 'border-white shadow-lg' 
+                      className={`flex-shrink-0 w-12 h-12 sm:w-14 sm:h-14 rounded-lg overflow-hidden border-2 transition-all ${
+                        index === currentIndex
+                          ? 'border-white shadow-lg'
                           : 'border-white/30 hover:border-white/60'
                       }`}
                     >

--- a/src/components/ImageGallery.tsx
+++ b/src/components/ImageGallery.tsx
@@ -256,7 +256,7 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
           {/* Content container - this defines the boundaries for button positioning */}
           <div
             ref={contentRef}
-            className="relative h-[95%] flex items-center justify-center md:p-8 2xl:max-w-[60vw] mx-auto"
+            className="relative h-full sm:h-[95%] flex items-center justify-center md:p-8 2xl:max-w-[60vw] mx-auto"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Close button - positioned within content container */}

--- a/src/components/ImageGallery.tsx
+++ b/src/components/ImageGallery.tsx
@@ -226,104 +226,97 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
           </DialogPrimitive.Title>
         </VisuallyHidden.Root>
         <div className="relative w-full h-full flex items-center justify-center overflow-hidden">
-          {/* Close button */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className="absolute top-2 sm:top-4 right-2 sm:right-4 z-50 text-white hover:bg-white/20 bg-black/30"
-            style={{
-              // Account for mobile safe area and navigation
-              top: 'max(0.5rem, env(safe-area-inset-top, 0px))',
-              right: 'max(0.5rem, env(safe-area-inset-right, 0px))',
-            }}
-            onClick={onClose}
-          >
-            <X className="h-5 w-5 sm:h-6 sm:w-6" />
-          </Button>
-
-          {/* Action buttons */}
-          <div
-            className="absolute top-2 sm:top-4 left-2 sm:left-4 z-50 flex gap-2"
-            style={{
-              // Account for mobile safe area and navigation
-              top: 'max(0.5rem, env(safe-area-inset-top, 0px))',
-              left: 'max(0.5rem, env(safe-area-inset-left, 0px))',
-            }}
-          >
+          {/* Content container - this defines the boundaries for button positioning */}
+          <div className="relative w-full h-full flex items-center justify-center md:p-8 max-w-7xl mx-auto">
+            {/* Close button - positioned within content container */}
             <Button
               variant="ghost"
               size="icon"
-              className="text-white hover:bg-white/20 bg-black/30"
-              onClick={handleDownload}
-              disabled={isDownloading}
-              title={isDownloading ? "Downloading..." : "Download image"}
-            >
-              {isDownloading ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Download className="h-4 w-4" />
-              )}
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="text-white hover:bg-white/20 bg-black/30"
-              onClick={handleOpenInNewTab}
-              title="Open in new tab"
-            >
-              <ExternalLink className="h-4 w-4" />
-            </Button>
-          </div>
-
-          {/* Navigation buttons */}
-          {images.length > 1 && (
-            <>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="absolute left-2 sm:left-4 top-1/2 -translate-y-1/2 z-50 text-white hover:bg-white/20 bg-black/30"
-                onClick={goToPrevious}
-              >
-                <ChevronLeft className="h-6 w-6 sm:h-7 sm:w-7" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="absolute right-2 sm:right-4 top-1/2 -translate-y-1/2 z-50 text-white hover:bg-white/20 bg-black/30"
-                onClick={goToNext}
-              >
-                <ChevronRight className="h-6 w-6 sm:h-7 sm:w-7" />
-              </Button>
-            </>
-          )}
-
-          {/* Main image with zoom functionality */}
-          <div
-            className="w-full h-full flex items-center justify-center p-4 md:p-8"
-            style={{
-              // Account for mobile safe areas, navigation buttons, and zoom controls
-              paddingTop: 'max(4rem, calc(env(safe-area-inset-top, 0px) + 3rem))',
-              paddingBottom: 'max(8rem, calc(env(safe-area-inset-bottom, 0px) + 8rem))',
-            }}
-          >
-            <TransformWrapper
-              initialScale={1}
-              minScale={0.5}
-              maxScale={5}
-              wheel={{ step: 0.1 }}
-              pinch={{ step: 5 }}
-              doubleClick={{ mode: "toggle", step: 0.7 }}
-              panning={{
-                velocityDisabled: true,
-                // Disable panning when not zoomed to allow navigation gestures
-                disabled: false
+              className="absolute top-2 sm:top-4 right-2 sm:right-7 z-50 text-white hover:bg-white/20 bg-black/30"
+              style={{
+                // Account for mobile safe area and navigation
+                top: 'max(0.5rem, env(safe-area-inset-top, 0px))',
               }}
-              // Reset transform when image changes
-              key={currentIndex}
-              centerOnInit={true}
-              limitToBounds={true}
-              centerZoomedOut={true}
+              onClick={onClose}
             >
+              <X className="h-5 w-5 sm:h-6 sm:w-6" />
+            </Button>
+
+            {/* Action buttons - positioned within content container */}
+            <div
+              className="absolute top-2 sm:top-4 left-2 sm:left-7 z-50 flex gap-2"
+              style={{
+                // Account for mobile safe area and navigation
+                top: 'max(0.5rem, env(safe-area-inset-top, 0px))',
+              }}
+            >
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-white hover:bg-white/20 bg-black/30"
+                onClick={handleDownload}
+                disabled={isDownloading}
+                title={isDownloading ? "Downloading..." : "Download image"}
+              >
+                {isDownloading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Download className="h-4 w-4" />
+                )}
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-white hover:bg-white/20 bg-black/30"
+                onClick={handleOpenInNewTab}
+                title="Open in new tab"
+              >
+                <ExternalLink className="h-4 w-4" />
+              </Button>
+            </div>
+
+            {/* Navigation buttons - positioned within content container */}
+            {images.length > 1 && (
+              <>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="absolute left-2 sm:left-8 top-1/2 -translate-y-1/2 z-50 text-white hover:bg-white/20 bg-black/30"
+                  onClick={goToPrevious}
+                >
+                  <ChevronLeft className="h-6 w-6 sm:h-7 sm:w-7" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="absolute right-2 sm:right-8 top-1/2 -translate-y-1/2 z-50 text-white hover:bg-white/20 bg-black/30"
+                  onClick={goToNext}
+                >
+                  <ChevronRight className="h-6 w-6 sm:h-7 sm:w-7" />
+                </Button>
+              </>
+            )}
+
+            {/* Main image with zoom functionality */}
+            <div className="w-full h-full flex items-center justify-center overflow-block">
+              <TransformWrapper
+                initialScale={1}
+                minScale={0.5}
+                maxScale={5}
+                wheel={{ step: 0.1 }}
+                pinch={{ step: 5 }}
+                doubleClick={{ mode: "toggle", step: 0.7 }}
+                panning={{
+                  velocityDisabled: true,
+                  // Disable panning when not zoomed to allow navigation gestures
+                  disabled: false
+                }}
+                // Reset transform when image changes
+                key={currentIndex}
+                centerOnInit={true}
+                limitToBounds={true}
+                centerZoomedOut={true}
+              >
               {/* Zoom controls positioned under the image */}
               <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-50">
                 <div className="bg-black/50 backdrop-blur-sm rounded-full p-1 flex gap-1">
@@ -346,7 +339,7 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
             </TransformWrapper>
           </div>
 
-          {/* Image counter and thumbnail navigation */}
+          {/* Image counter and thumbnail navigation - positioned within content container */}
           {images.length > 1 && (
             <div
               className="absolute bottom-20 left-1/2 -translate-x-1/2 z-50 flex flex-col items-center gap-2"
@@ -384,6 +377,7 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
               </div>
             </div>
           )}
+          </div>
         </div>
       </ImageGalleryDialogContent>
     </DialogPrimitive.Root>

--- a/src/components/ImageGallery.tsx
+++ b/src/components/ImageGallery.tsx
@@ -1,0 +1,404 @@
+import React, { useState, useEffect } from 'react';
+import { ChevronLeft, ChevronRight, X, Download, ExternalLink, ZoomIn, ZoomOut, RotateCcw, Loader2 } from 'lucide-react';
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Button } from '@/components/ui/button';
+import * as VisuallyHidden from '@radix-ui/react-visually-hidden';
+import { cn } from "@/lib/utils";
+import { TransformWrapper, TransformComponent, useControls } from "react-zoom-pan-pinch";
+import { useToast } from '@/hooks/useToast';
+
+interface ImageGalleryProps {
+  images: string[];
+  isOpen: boolean;
+  onClose: () => void;
+  initialIndex?: number;
+}
+
+/**
+ * ImageGallery component with pinch zoom functionality
+ * 
+ * Features:
+ * - Pinch to zoom on touch devices
+ * - Mouse wheel zoom on desktop
+ * - Double-click to toggle zoom
+ * - Pan when zoomed in
+ * - Zoom controls (desktop: top-right, mobile: bottom-center)
+ * - Zoom resets when changing images
+ * - Supports min/max zoom limits (0.5x to 5x)
+ */
+
+// Custom DialogContent without the automatic close button
+const ImageGalleryDialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPrimitive.Portal>
+    <DialogPrimitive.Overlay className="fixed inset-0 z-[100000] bg-black/80" />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-[100001] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background shadow-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {/* No automatic close button */}
+    </DialogPrimitive.Content>
+  </DialogPrimitive.Portal>
+));
+ImageGalleryDialogContent.displayName = "ImageGalleryDialogContent";
+
+// Zoom controls component that uses the useControls hook
+function ZoomControls() {
+  const { zoomIn, zoomOut, resetTransform } = useControls();
+  
+  return (
+    <div className="flex gap-1">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="text-white hover:bg-white/20 bg-black/30"
+        onClick={() => zoomIn()}
+        title="Zoom in"
+      >
+        <ZoomIn className="h-4 w-4 md:h-5 md:w-5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="text-white hover:bg-white/20 bg-black/30"
+        onClick={() => zoomOut()}
+        title="Zoom out"
+      >
+        <ZoomOut className="h-4 w-4 md:h-5 md:w-5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="text-white hover:bg-white/20 bg-black/30"
+        onClick={() => resetTransform()}
+        title="Reset zoom"
+      >
+        <RotateCcw className="h-4 w-4 md:h-5 md:w-5" />
+      </Button>
+    </div>
+  );
+}
+
+export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: ImageGalleryProps) {
+  const [currentIndex, setCurrentIndex] = useState(initialIndex);
+  const [isDownloading, setIsDownloading] = useState(false);
+  const { toast } = useToast();
+
+  const goToPrevious = () => {
+    setCurrentIndex((prev) => (prev === 0 ? images.length - 1 : prev - 1));
+  };
+
+  const goToNext = () => {
+    setCurrentIndex((prev) => (prev === images.length - 1 ? 0 : prev + 1));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowLeft') {
+      goToPrevious();
+    } else if (e.key === 'ArrowRight') {
+      goToNext();
+    } else if (e.key === 'Escape') {
+      onClose();
+    }
+  };
+
+  const handleDownload = async () => {
+    if (isDownloading) return;
+    
+    setIsDownloading(true);
+    
+    try {
+      const imageUrl = images[currentIndex];
+      if (!imageUrl) {
+        throw new Error('No image URL provided');
+      }
+      
+      // Extract filename from URL or create a default one
+      const urlParts = imageUrl.split('/');
+      const urlFilename = urlParts[urlParts.length - 1] || '';
+      
+      // Remove query parameters first
+      const cleanFilename = urlFilename.split('?')[0] || '';
+      
+      // Check if the clean filename has a valid image extension
+      const hasExtension = cleanFilename.includes('.') && 
+        cleanFilename.split('.').pop()?.match(/^(jpg|jpeg|png|gif|webp|svg)$/i) !== undefined;
+      
+      const filename = hasExtension 
+        ? cleanFilename 
+        : `chat-image-${currentIndex + 1}.jpg`;
+      
+      // Try to fetch the image and download it as a blob (handles CORS better)
+      try {
+        const response = await fetch(imageUrl);
+        if (!response.ok) throw new Error('Network response was not ok');
+        
+        const blob = await response.blob();
+        const blobUrl = URL.createObjectURL(blob);
+        
+        const link = document.createElement('a');
+        link.href = blobUrl;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        
+        // Clean up the blob URL
+        URL.revokeObjectURL(blobUrl);
+        
+        toast({
+          title: 'Download started',
+          description: `Downloading ${filename}`,
+        });
+      } catch (fetchError) {
+        // Fallback: try direct download (may not work for CORS images)
+        console.warn('Fetch download failed, trying direct download:', fetchError);
+        const link = document.createElement('a');
+        link.href = imageUrl;
+        link.download = filename;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        
+        toast({
+          title: 'Download started',
+          description: `Downloading ${filename} (fallback method)`,
+        });
+      }
+    } catch (error) {
+      console.error('Download failed:', error);
+      
+      toast({
+        title: 'Download failed',
+        description: 'Opening image in new tab instead',
+        variant: 'destructive',
+      });
+      
+      // Final fallback: open in new tab
+      window.open(images[currentIndex], '_blank', 'noopener,noreferrer');
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  const handleOpenInNewTab = () => {
+    const imageUrl = images[currentIndex];
+    if (imageUrl) {
+      window.open(imageUrl, '_blank');
+    }
+  };
+
+  // Update current index when initialIndex changes
+  useEffect(() => {
+    setCurrentIndex(initialIndex);
+  }, [initialIndex]);
+
+  if (!isOpen || images.length === 0) return null;
+
+  return (
+    <DialogPrimitive.Root open={isOpen} onOpenChange={onClose}>
+      <ImageGalleryDialogContent 
+        className="max-w-[100vw] max-h-[100vh] w-[100vw] h-[100vh] p-0 bg-black/95 border-0 md:max-w-[100vw] md:max-h-[100vh]"
+        onKeyDown={handleKeyDown}
+        style={{
+          // Ensure the gallery covers the full viewport including safe areas on mobile
+          top: '0',
+          left: '0',
+          transform: 'none',
+          width: '100vw',
+          height: '100vh',
+          maxWidth: '100vw',
+          maxHeight: '100vh',
+        }}
+      >
+        <VisuallyHidden.Root>
+          <DialogPrimitive.Title>
+            Image Gallery - Viewing image {currentIndex + 1} of {images.length}
+          </DialogPrimitive.Title>
+        </VisuallyHidden.Root>
+        <div className="relative w-full h-full flex items-center justify-center overflow-hidden">
+          {/* Close button */}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="absolute top-2 md:top-4 right-2 md:right-4 z-50 text-white hover:bg-white/20 bg-black/30"
+            style={{
+              // Account for mobile safe area and navigation
+              top: 'max(0.5rem, env(safe-area-inset-top, 0px))',
+            }}
+            onClick={onClose}
+          >
+            <X className="h-5 w-5 md:h-6 md:w-6" />
+          </Button>
+
+          {/* Action buttons */}
+          <div 
+            className="absolute top-2 md:top-4 left-2 md:left-4 z-50 flex gap-2"
+            style={{
+              // Account for mobile safe area and navigation
+              top: 'max(0.5rem, env(safe-area-inset-top, 0px))',
+            }}
+          >
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-white hover:bg-white/20 bg-black/30"
+              onClick={handleDownload}
+              disabled={isDownloading}
+              title={isDownloading ? "Downloading..." : "Download image"}
+            >
+              {isDownloading ? (
+                <Loader2 className="h-4 w-4 md:h-5 md:w-5 animate-spin" />
+              ) : (
+                <Download className="h-4 w-4 md:h-5 md:w-5" />
+              )}
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-white hover:bg-white/20 bg-black/30"
+              onClick={handleOpenInNewTab}
+              title="Open in new tab"
+            >
+              <ExternalLink className="h-4 w-4 md:h-5 md:w-5" />
+            </Button>
+          </div>
+
+          {/* Navigation buttons */}
+          {images.length > 1 && (
+            <>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="absolute left-2 md:left-4 top-1/2 -translate-y-1/2 z-50 text-white hover:bg-white/20 bg-black/30"
+                onClick={goToPrevious}
+              >
+                <ChevronLeft className="h-6 w-6 md:h-8 md:w-8" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="absolute right-2 md:right-4 top-1/2 -translate-y-1/2 z-50 text-white hover:bg-white/20 bg-black/30"
+                onClick={goToNext}
+              >
+                <ChevronRight className="h-6 w-6 md:h-8 md:w-8" />
+              </Button>
+            </>
+          )}
+
+          {/* Main image with zoom functionality */}
+          <div 
+            className="w-full h-full flex items-center justify-center p-4 md:p-8"
+            style={{
+              // Account for mobile safe areas and navigation buttons
+              paddingTop: 'max(4rem, calc(env(safe-area-inset-top, 0px) + 3rem))',
+              paddingBottom: 'max(6rem, calc(env(safe-area-inset-bottom, 0px) + 6rem))',
+            }}
+          >
+            <TransformWrapper
+              initialScale={1}
+              minScale={0.5}
+              maxScale={5}
+              wheel={{ step: 0.1 }}
+              pinch={{ step: 5 }}
+              doubleClick={{ mode: "toggle", step: 0.7 }}
+              panning={{ 
+                velocityDisabled: true,
+                // Disable panning when not zoomed to allow navigation gestures
+                disabled: false
+              }}
+              // Reset transform when image changes
+              key={currentIndex}
+              centerOnInit={true}
+              limitToBounds={true}
+              centerZoomedOut={true}
+            >
+              {/* Desktop zoom controls positioned absolutely within the transform wrapper */}
+              <div 
+                className="absolute top-2 md:top-4 right-16 md:right-20 z-50 hidden md:flex gap-1"
+                style={{
+                  // Account for mobile safe area and navigation
+                  top: 'max(0.5rem, env(safe-area-inset-top, 0px))',
+                }}
+              >
+                <ZoomControls />
+              </div>
+
+              {/* Mobile zoom controls positioned at bottom */}
+              <div 
+                className="absolute bottom-20 left-1/2 -translate-x-1/2 z-50 md:hidden flex gap-1"
+                style={{
+                  // Account for mobile safe area
+                  bottom: 'max(5rem, calc(env(safe-area-inset-bottom, 0px) + 7rem))',
+                }}
+              >
+                <ZoomControls />
+              </div>
+              
+              <TransformComponent
+                wrapperClass="!w-full !h-full"
+                contentClass="!w-full !h-full flex items-center justify-center"
+              >
+                <img
+                  src={images[currentIndex]}
+                  alt={`Chat image ${currentIndex + 1}`}
+                  className="max-w-full max-h-full object-contain"
+                  onClick={(e) => e.stopPropagation()}
+                  draggable={false}
+                />
+              </TransformComponent>
+            </TransformWrapper>
+          </div>
+
+          {/* Image counter and thumbnail navigation */}
+          {images.length > 1 && (
+            <div 
+              className="absolute bottom-4 left-1/2 -translate-x-1/2 z-50 flex flex-col items-center gap-2"
+              style={{
+                // Account for mobile safe area
+                bottom: 'max(1rem, calc(env(safe-area-inset-bottom, 0px) + 1rem))',
+              }}
+            >
+              {/* Image counter */}
+              <div className="bg-black/50 text-white px-3 py-1 rounded-full text-sm">
+                {currentIndex + 1} of {images.length}
+              </div>
+              
+              {/* Thumbnail navigation */}
+              <div className="flex gap-2 max-w-[calc(100vw-2rem)] overflow-x-auto px-2">
+                <div className="flex gap-2 pb-2">
+                  {images.map((image, index) => (
+                    <button
+                      key={index}
+                      onClick={() => setCurrentIndex(index)}
+                      className={`flex-shrink-0 w-12 h-12 md:w-16 md:h-16 rounded-lg overflow-hidden border-2 transition-all ${
+                        index === currentIndex 
+                          ? 'border-white shadow-lg' 
+                          : 'border-white/30 hover:border-white/60'
+                      }`}
+                    >
+                      <img
+                        src={image}
+                        alt={`Thumbnail ${index + 1}`}
+                        className="w-full h-full object-cover"
+                      />
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </ImageGalleryDialogContent>
+    </DialogPrimitive.Root>
+  );
+}

--- a/src/components/ImageGallery.tsx
+++ b/src/components/ImageGallery.tsx
@@ -207,7 +207,7 @@ export function ImageGallery({ images, isOpen, onClose, initialIndex = 0 }: Imag
   return (
     <DialogPrimitive.Root open={isOpen} onOpenChange={onClose}>
       <ImageGalleryDialogContent 
-        className="max-w-[100vw] max-h-[100vh] w-[100vw] h-[100vh] p-0 bg-black/95 border-0 md:max-w-[100vw] md:max-h-[100vh]"
+        className="max-w-[100vw] max-h-[100vh] w-[100vw] h-[100vh] p-0 bg-background/85 border-0 md:max-w-[100vw] md:max-h-[100vh]"
         onKeyDown={handleKeyDown}
         style={{
           // Ensure the gallery covers the full viewport including safe areas on mobile

--- a/src/components/NoteContent.test.tsx
+++ b/src/components/NoteContent.test.tsx
@@ -243,11 +243,11 @@ describe('NoteContent', () => {
     // Check that the images have the correct attributes
     expect(images[0]).toHaveAttribute('src', 'https://example.com/image.jpg');
     expect(images[0]).toHaveAttribute('alt', 'Shared image');
-    expect(images[0]).toHaveClass('rounded-lg');
+    expect(images[0]).toHaveClass('object-cover');
 
     expect(images[1]).toHaveAttribute('src', 'https://picsum.photos/200/300.png');
     expect(images[1]).toHaveAttribute('alt', 'Shared image');
-    expect(images[1]).toHaveClass('rounded-lg');
+    expect(images[1]).toHaveClass('object-cover');
 
     // Should not have any links for the image URLs
     const links = screen.queryAllByRole('link');

--- a/src/components/NoteContent.tsx
+++ b/src/components/NoteContent.tsx
@@ -350,17 +350,6 @@ export function NoteContent({
                 alt="Shared image"
                 className="max-h-64 w-auto"
                 onClick={() => handleImageClick(url, allImages)}
-                onError={(e) => {
-                  // If image fails to load, fall back to link
-                  const fallbackLink = document.createElement('a');
-                  fallbackLink.href = url;
-                  fallbackLink.target = '_blank';
-                  fallbackLink.rel = 'noopener noreferrer';
-                  fallbackLink.className = 'text-blue-500 hover:underline';
-                  fallbackLink.textContent = url;
-                  const eventTarget = e.currentTarget as HTMLElement;
-                  eventTarget.parentNode?.replaceChild(fallbackLink, eventTarget);
-                }}
               />
             </div>
           );

--- a/src/components/chat/MediaAttachment.tsx
+++ b/src/components/chat/MediaAttachment.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { X, Download, ExternalLink } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { ChatImage } from '@/components/ChatImage';
 import { cn } from '@/lib/utils';
 
 interface MediaAttachmentProps {
@@ -12,6 +13,7 @@ interface MediaAttachmentProps {
   className?: string;
   onRemove?: () => void;
   showRemove?: boolean;
+  onImageClick?: (url: string) => void;
 }
 
 export function MediaAttachment({
@@ -21,7 +23,8 @@ export function MediaAttachment({
   name,
   className,
   onRemove,
-  showRemove = false
+  showRemove = false,
+  onImageClick
 }: MediaAttachmentProps) {
   const [imageError, setImageError] = useState(false);
 
@@ -49,12 +52,12 @@ export function MediaAttachment({
   if (mediaType === 'image' && !imageError) {
     return (
       <div className={cn("relative inline-block max-w-sm", className)}>
-        <img
+        <ChatImage
           src={url}
           alt={fileName}
-          className="rounded-lg max-h-64 w-auto object-cover"
+          className="max-h-64 w-auto"
           onError={() => setImageError(true)}
-          loading="lazy"
+          onClick={() => onImageClick?.(url)}
         />
         {showRemove && onRemove && (
           <Button

--- a/src/hooks/useImageGallery.ts
+++ b/src/hooks/useImageGallery.ts
@@ -1,0 +1,45 @@
+import { useState, useCallback } from 'react';
+
+export function useImageGallery() {
+  const [galleryOpen, setGalleryOpen] = useState(false);
+  const [galleryIndex, setGalleryIndex] = useState(0);
+  const [allImages, setAllImages] = useState<string[]>([]);
+
+  const handleImageClick = useCallback((imageUrl: string, currentImages: string[] = allImages) => {
+    const imageIndex = currentImages.indexOf(imageUrl);
+    if (imageIndex !== -1) {
+      setGalleryIndex(imageIndex);
+      setGalleryOpen(true);
+    } else {
+      // Add the new image to the list and open gallery
+      const newImages = [...currentImages, imageUrl];
+      setAllImages(newImages);
+      setGalleryIndex(newImages.length - 1);
+      setGalleryOpen(true);
+    }
+  }, [allImages]);
+
+  const openGallery = useCallback((index: number) => {
+    setGalleryIndex(index);
+    setGalleryOpen(true);
+  }, []);
+
+  const closeGallery = useCallback(() => {
+    setGalleryOpen(false);
+  }, []);
+
+  const updateImages = useCallback((images: string[]) => {
+    setAllImages(images);
+  }, []);
+
+  return {
+    galleryOpen,
+    galleryIndex,
+    allImages,
+    handleImageClick,
+    openGallery,
+    closeGallery,
+    updateImages,
+    setGalleryIndex
+  };
+}


### PR DESCRIPTION
This change introduces an image gallery view for images in the chat, complete with options to:
- Zoom in/out, or reset zoom
- Download the image
- Open the image source externally
- Pinch zoom on supported devices (i.e., mobile phones)
- Browse multiple images

Additional behaviors:
- Gallery should close when clicking outside of image content

Previews:
<img width="3167" height="1320" alt="image" src="https://github.com/user-attachments/assets/47d6d3e7-b4b6-4e7a-a2e1-486745d6d581" />
<img width="409" height="691" alt="image" src="https://github.com/user-attachments/assets/8e96e109-8f3f-46ad-81ad-a6983e836521" />
