### PR TITLE
Attempt to address GitHub linter failure.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "input-otp": "^1.2.4",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
-        "nostr-tools": "^2.15.1",
+        "nostr-tools": "^2.16.2",
         "pluralize": "^8.0.0",
         "qrcode": "^1.5.4",
         "react": "^18.3.1",
@@ -7019,9 +7019,10 @@
       }
     },
     "node_modules/nostr-tools": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.15.1.tgz",
-      "integrity": "sha512-LpetHDR9ltnkpJDkva/SONgyKBbsoV+5yLB8DWc0/U3lCWGtoWJw6Nbc2vR2Ai67RIQYrBQeZLyMlhwVZRK/9A==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.16.2.tgz",
+      "integrity": "sha512-ZxH9EbSt5ypURZj2TGNJxZd0Omb5ag5KZSu8IyJMCdLyg2KKz+2GA0sP/cSawCQEkyviIN4eRT4G2gB/t9lMRw==",
+      "license": "Unlicense",
       "dependencies": {
         "@noble/ciphers": "^0.5.1",
         "@noble/curves": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",
-    "nostr-tools": "^2.15.1",
+    "nostr-tools": "^2.16.2",
     "pluralize": "^8.0.0",
     "qrcode": "^1.5.4",
     "react": "^18.3.1",


### PR DESCRIPTION
The linter run reports the following error:
<img width="1046" height="437" alt="image" src="https://github.com/user-attachments/assets/c69652ba-8245-4a3e-a1d8-3a658b4e17cd" />

However, these are valid types for nip57.makeZapRequest()'s `event` parameter:
<img width="455" height="189" alt="image" src="https://github.com/user-attachments/assets/55b1d558-20c8-4979-8b7b-badaf24b0e16" />

This change set is an attempt to address the linter failure that can't be replicated locally.