### PR TITLE
ui/108-use-nprofile-string-instead-of-markdown-like-user-mention-format

### DIFF
--- a/src/components/NoteContent.test.tsx
+++ b/src/components/NoteContent.test.tsx
@@ -219,6 +219,37 @@ describe('NoteContent', () => {
     expect(linkText).toEqual("@Swift Falcon");
   });
 
+  it('renders standalone npub mentions (without nostr: prefix)', () => {
+    const event: NostrEvent = {
+      id: 'test-id',
+      pubkey: 'test-pubkey',
+      created_at: Math.floor(Date.now() / 1000),
+      kind: 1,
+      tags: [],
+      content: `Mentioning npub1zg69v7ys40x77y352eufp27daufrg4ncjz4ummcjx3t83y9tehhsqepuh0 directly`,
+      sig: 'test-sig',
+    };
+
+    render(
+      <TestApp>
+        <NoteContent event={event} />
+      </TestApp>
+    );
+
+    // The mention should be rendered as a button
+    const mention = screen.getByRole('button');
+    expect(mention).toBeInTheDocument();
+
+    // Should have muted styling for generated names (gray instead of blue)
+    expect(mention).toHaveClass('text-gray-500');
+    expect(mention).not.toHaveClass('text-blue-500');
+
+    // The text should start with @ and contain a generated name (not a truncated npub)
+    const linkText = mention.textContent;
+    expect(linkText).not.toMatch(/^@npub1/); // Should not be a truncated npub
+    expect(linkText).toEqual("@Swift Falcon");
+  });
+
   it('renders image URLs as images instead of links', () => {
     const event: NostrEvent = {
       id: 'test-id',

--- a/src/components/NoteContent.tsx
+++ b/src/components/NoteContent.tsx
@@ -64,9 +64,10 @@ function containsMarkdown(text: string): boolean {
   // Check for markdown links, but exclude user mentions in the format @[name](pubkey)
   const hasMarkdownLinks = /\[.*?\]\(.*?\)/.test(text);
   const hasUserMentions = /@\[.*?\]\([0-9a-f]{64}\)/i.test(text);
+  const hasNpubMentions = /npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/.test(text);
 
-  // Only consider it markdown if it has markdown links but no user mentions
-  const hasRealMarkdown = markdownPatterns.some(pattern => pattern.test(text)) || (hasMarkdownLinks && !hasUserMentions);
+  // Only consider it markdown if it has markdown links but no user mentions or npub mentions
+  const hasRealMarkdown = markdownPatterns.some(pattern => pattern.test(text)) || (hasMarkdownLinks && !hasUserMentions && !hasNpubMentions);
 
   return hasRealMarkdown;
 }
@@ -321,7 +322,7 @@ export function NoteContent({
     }
 
     // If no markdown, use the original regex-based processing
-    const regex = /(https?:\/\/[^\s]+)|nostr:(npub1|note1|nprofile1|nevent1|naddr1)([023456789acdefghjklmnpqrstuvwxyz]+)|@\[([^\]]+)\]\(([^)]+)\)|(#\w+)/g;
+    const regex = /(https?:\/\/[^\s]+)|(?:nostr:)?(npub1|note1|nprofile1|nevent1|naddr1)([023456789acdefghjklmnpqrstuvwxyz]+)|@\[([^\]]+)\]\(([^)]+)\)|(#\w+)/g;
 
     const parts: React.ReactNode[] = [];
     let lastIndex = 0;

--- a/src/components/chat/SimpleMentionTypeahead.tsx
+++ b/src/components/chat/SimpleMentionTypeahead.tsx
@@ -75,7 +75,7 @@ function MentionItem({
 
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
-          <span className="font-medium text-sm truncate text-gray-100">{friendlyName}</span>
+          <span className="font-medium text-sm truncate text-foreground">{friendlyName}</span>
           {user.role && (
             <span className={cn("text-xs font-medium", roleColor)}>
               {user.role}
@@ -83,7 +83,7 @@ function MentionItem({
           )}
         </div>
         {username !== friendlyName && (
-          <div className="text-xs text-gray-400 truncate">@{username}</div>
+          <div className="text-xs text-muted-foreground truncate">@{username}</div>
         )}
       </div>
     </div>
@@ -269,7 +269,7 @@ export function SimpleMentionTypeahead({
             }
           </div>
         ) : isLoading ? (
-          <div className="py-4 text-center text-sm text-gray-400">
+          <div className="py-4 text-center text-sm text-muted-foreground">
             Searching...
           </div>
         ) : filteredUsers.length === 0 ? (
@@ -283,7 +283,7 @@ export function SimpleMentionTypeahead({
           </div>
         ) : (
           <div className="p-2">
-            <div className="text-xs font-medium text-gray-400 px-2 py-1 mb-1">
+            <div className="text-xs font-medium text-muted-foreground px-2 py-1 mb-1">
               {communityId ? "Community Members" : "Thread Participants"}
             </div>
             {filteredUsers.map((user, index) => (

--- a/src/components/chat/SimpleMentionTypeahead.tsx
+++ b/src/components/chat/SimpleMentionTypeahead.tsx
@@ -1,27 +1,20 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useAuthor } from "@/hooks/useAuthor";
 import { useCommunityMembers } from "@/hooks/useCommunityMembers";
 import { useUserMetadataSearch } from "@/hooks/useUserMetadataSearch";
 import { useUserMetadataBatch } from "@/hooks/useUserMetadataBatch";
-import { useClickOutside } from "@/hooks/useClickOutside";
 import { genUserName } from "@/lib/genUserName";
 import { cn } from "@/lib/utils";
 import type { NostrMetadata, NostrEvent } from "@nostrify/nostrify";
-import type * as React from "react";
+import { nip19 } from "nostr-tools";
 
-interface UserMentionAutocompleteProps {
+interface SimpleMentionTypeaheadProps {
   open: boolean;
-  onOpenChange: (open: boolean) => void;
+  onClose: () => void;
   query: string;
-  onSelect: (pubkey: string, displayName: string) => void;
+  onSelect: (npub: string, displayName: string) => void;
   communityId?: string;
-  triggerRef: React.RefObject<HTMLElement>;
-  onKeyDown?: (e: React.KeyboardEvent<Element>) => void;
-  selectedIndex?: number;
-  onSelectedIndexChange?: (index: number) => void;
-  onEnterKey?: (handler: () => boolean) => void;
-  // Thread context props
   rootMessage?: NostrEvent;
   threadReplies?: NostrEvent[];
 }
@@ -34,15 +27,18 @@ interface MentionableUser {
   isOnline?: boolean;
 }
 
-function UserMentionItem({ user, onSelect, isSelected }: {
+function MentionItem({ 
+  user, 
+  onSelect, 
+  isHighlighted 
+}: {
   user: MentionableUser;
-  onSelect: (pubkey: string, displayName: string) => void;
-  isSelected?: boolean;
+  onSelect: () => void;
+  isHighlighted: boolean;
 }) {
   const { data: author } = useAuthor(user.pubkey);
   const metadata = author?.metadata || user.metadata;
-
-  // Use the most friendly name available for display and selection
+  
   const friendlyName = metadata?.display_name || metadata?.name || user.displayName;
   const username = metadata?.name || genUserName(user.pubkey);
   const avatar = metadata?.picture;
@@ -57,13 +53,13 @@ function UserMentionItem({ user, onSelect, isSelected }: {
 
   return (
     <div
-      onClick={() => onSelect(user.pubkey, friendlyName)}
       className={cn(
         "flex items-center gap-3 px-3 py-2 cursor-pointer rounded-sm transition-colors",
-        isSelected
+        isHighlighted
           ? "bg-blue-600/30"
           : "hover:bg-gray-700"
       )}
+      onClick={onSelect}
     >
       <div className="relative">
         <Avatar className="h-8 w-8">
@@ -94,82 +90,42 @@ function UserMentionItem({ user, onSelect, isSelected }: {
   );
 }
 
-export function UserMentionAutocomplete({
+export function SimpleMentionTypeahead({
   open,
-  onOpenChange,
+  onClose,
   query,
   onSelect,
   communityId,
-  triggerRef: _triggerRef,
-  onKeyDown: _onKeyDown,
-  selectedIndex: externalSelectedIndex,
-  onSelectedIndexChange,
-  onEnterKey,
   rootMessage,
   threadReplies
-}: UserMentionAutocompleteProps) {
+}: SimpleMentionTypeaheadProps) {
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [mentionableUsers, setMentionableUsers] = useState<MentionableUser[]>([]);
-  const [internalSelectedIndex, setInternalSelectedIndex] = useState(-1); // Start with no selection
   const { data: communityMembers } = useCommunityMembers(communityId || null);
-
-  // Set up click outside handler to close the autocomplete
-  const autocompleteRef = useClickOutside<HTMLDivElement>(() => {
-    if (open) {
-      onOpenChange(false);
-    }
-  });
-
+  const containerRef = useRef<HTMLDivElement>(null);
+  
   // Get pubkeys for batch metadata loading
-  const memberPubkeys = useMemo(() => {
-    return communityMembers?.map(m => m.pubkey) || [];
-  }, [communityMembers]);
-
+  const memberPubkeys = communityMembers?.map(m => m.pubkey) || [];
+  
   // Also get pubkeys for thread participants
-  const threadParticipantPubkeys = useMemo(() => {
-    if (!communityId && (rootMessage || threadReplies)) {
-      const pubkeys = new Set<string>();
-      if (rootMessage) {
-        pubkeys.add(rootMessage.pubkey);
-      }
-      if (threadReplies) {
-        threadReplies.forEach(reply => pubkeys.add(reply.pubkey));
-      }
-      return Array.from(pubkeys);
+  const threadParticipantPubkeys: string[] = [];
+  if (!communityId && (rootMessage || threadReplies)) {
+    if (rootMessage) {
+      threadParticipantPubkeys.push(rootMessage.pubkey);
     }
-    return [];
-  }, [communityId, rootMessage, threadReplies]);
-
-  const allPubkeys = useMemo(() => {
-    return [...memberPubkeys, ...threadParticipantPubkeys];
-  }, [memberPubkeys, threadParticipantPubkeys]);
-
+    if (threadReplies) {
+      threadReplies.forEach(reply => {
+        if (!threadParticipantPubkeys.includes(reply.pubkey)) {
+          threadParticipantPubkeys.push(reply.pubkey);
+        }
+      });
+    }
+  }
+  
+  const allPubkeys = [...memberPubkeys, ...threadParticipantPubkeys];
   const { data: metadataMap } = useUserMetadataBatch(allPubkeys);
-
   const { filteredUsers, isLoading } = useUserMetadataSearch(mentionableUsers, query);
-
-  // Use external index if provided, otherwise use internal state
-  const selectedIndex = externalSelectedIndex ?? internalSelectedIndex;
-
-  // Handle Enter key selection
-  const handleEnterKey = useCallback(() => {
-    // Use filteredUsers for selection, not mentionableUsers
-    // Only select if there's a valid selection (selectedIndex >= 0)
-    if (filteredUsers.length > 0 && selectedIndex >= 0 && selectedIndex < filteredUsers.length) {
-      const user = filteredUsers[selectedIndex];
-      const displayName = user.displayName;
-      onSelect(user.pubkey, displayName);
-      return true;
-    }
-    return false;
-  }, [filteredUsers, selectedIndex, onSelect]);
-
-  // Expose the Enter key handler to parent
-  useEffect(() => {
-    if (onEnterKey) {
-      onEnterKey(handleEnterKey);
-    }
-  }, [onEnterKey, handleEnterKey]);
-
+  
   // Prepare user list with metadata
   useEffect(() => {
     let users: MentionableUser[] = [];
@@ -213,80 +169,95 @@ export function UserMentionAutocomplete({
           metadata
         };
       });
-    } else if (!communityId) {
-      // No context available - empty list
-      users = [];
     }
 
     setMentionableUsers(users);
   }, [communityMembers, metadataMap, communityId, rootMessage, threadReplies]);
 
-  // Handle keyboard navigation
+  // Reset highlighted index when users change
+  useEffect(() => {
+    setHighlightedIndex(-1);
+  }, [filteredUsers]);
+
+  // Handle keyboard navigation - this component fully manages its own keyboard events
   useEffect(() => {
     if (!open) return;
 
-    const handleKeyDown = (e: globalThis.KeyboardEvent) => {
-      if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        // If no selection, select first item, otherwise move down
-        const newIndex = selectedIndex < 0 ? 0 : Math.min(selectedIndex + 1, filteredUsers.length - 1);
-        if (onSelectedIndexChange) {
-          onSelectedIndexChange(newIndex);
-        } else {
-          setInternalSelectedIndex(newIndex);
-        }
-      } else if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        // If at first item or no selection, move to last item, otherwise move up
-        const newIndex = selectedIndex <= 0 ? Math.max(filteredUsers.length - 1, 0) : selectedIndex - 1;
-        if (onSelectedIndexChange) {
-          onSelectedIndexChange(newIndex);
-        } else {
-          setInternalSelectedIndex(newIndex);
-        }
-      } else if (e.key === 'Enter' || e.key === 'Tab') {
-        e.preventDefault();
-        // Only select if there's a valid selection
-        if (selectedIndex >= 0 && filteredUsers[selectedIndex]) {
-          const user = filteredUsers[selectedIndex];
-          const displayName = user.displayName;
-          onSelect(user.pubkey, displayName);
-        }
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!filteredUsers.length) return;
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          e.stopPropagation();
+          setHighlightedIndex(prev => 
+            prev < filteredUsers.length - 1 ? prev + 1 : 0
+          );
+          break;
+          
+        case 'ArrowUp':
+          e.preventDefault();
+          e.stopPropagation();
+          setHighlightedIndex(prev => 
+            prev > 0 ? prev - 1 : filteredUsers.length - 1
+          );
+          break;
+          
+        case 'Enter':
+        case 'Tab':
+          e.preventDefault();
+          e.stopPropagation();
+          if (highlightedIndex >= 0 && highlightedIndex < filteredUsers.length) {
+            selectUser(filteredUsers[highlightedIndex]);
+          } else if (filteredUsers.length > 0) {
+            // If no item is highlighted but we have users, select the first one
+            selectUser(filteredUsers[0]);
+          }
+          break;
+          
+        case 'Escape':
+          e.preventDefault();
+          e.stopPropagation();
+          onClose();
+          break;
       }
     };
 
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [open, filteredUsers, selectedIndex, onSelect, onSelectedIndexChange, onEnterKey]);
+    // Use capture phase to ensure we get the event before other handlers
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  }, [open, filteredUsers, highlightedIndex, onClose]);
 
-  // Update selected index when users change to prevent out of bounds
+  // Handle clicking outside to close
   useEffect(() => {
-    if (filteredUsers.length > 0) {
-      // If no selection or selection is out of bounds, don't auto-select
-      if (selectedIndex < 0 || selectedIndex >= filteredUsers.length) {
-        // Keep no selection (-1) instead of auto-selecting first item
-        if (onSelectedIndexChange) {
-          onSelectedIndexChange(-1);
-        } else {
-          setInternalSelectedIndex(-1);
-        }
+    if (!open) return;
+    
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        onClose();
       }
-    } else {
-      // No users available, reset to no selection
-      if (onSelectedIndexChange) {
-        onSelectedIndexChange(-1);
-      } else {
-        setInternalSelectedIndex(-1);
-      }
-    }
-  }, [filteredUsers, selectedIndex, onSelectedIndexChange]);
+    };
+    
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open, onClose]);
+
+  // Helper function to select a user
+  const selectUser = (user: MentionableUser) => {
+    const displayName = user.metadata?.display_name || user.metadata?.name || user.displayName;
+    const npub = nip19.npubEncode(user.pubkey);
+    onSelect(npub, displayName);
+  };
 
   if (!open) {
     return null;
   }
 
   return (
-    <div ref={autocompleteRef} className="absolute bottom-full left-0 mb-2 w-80 z-[9999] bg-popover border border-border rounded-md shadow-lg">
+    <div 
+      ref={containerRef}
+      className="absolute bottom-full left-0 mb-2 w-80 z-[9999] bg-popover border border-border rounded-md shadow-lg"
+    >
       <div className="max-h-64 overflow-y-auto">
         {mentionableUsers.length === 0 ? (
           <div className="py-4 text-center text-sm text-muted-foreground">
@@ -316,11 +287,11 @@ export function UserMentionAutocomplete({
               {communityId ? "Community Members" : "Thread Participants"}
             </div>
             {filteredUsers.map((user, index) => (
-              <UserMentionItem
+              <MentionItem
                 key={user.pubkey}
                 user={user}
-                onSelect={onSelect}
-                isSelected={index === selectedIndex}
+                isHighlighted={index === highlightedIndex}
+                onSelect={() => selectUser(user)}
               />
             ))}
           </div>

--- a/src/components/messaging/BaseMessageInput.tsx
+++ b/src/components/messaging/BaseMessageInput.tsx
@@ -8,7 +8,7 @@ import { PollCard } from "@/components/PollCard";
 import { CalendarEventCard } from "@/components/CalendarEventCard";
 import { EditEventDialog } from "@/components/EditEventDialog";
 import { EmojiAutocomplete } from "@/components/ui/emoji-autocomplete";
-import { UserMentionAutocomplete } from "@/components/chat/UserMentionAutocomplete";
+import { SimpleMentionTypeahead } from "@/components/chat/SimpleMentionTypeahead";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useToast } from "@/hooks/useToast";
 import { extractShortcodeContext, searchEmojis, type EmojiData } from "@/lib/emojiUtils";
@@ -73,7 +73,6 @@ export function BaseMessageInput({
   // User mentions state
   const [showMentionAutocomplete, setShowMentionAutocomplete] = useState(false);
   const [mentionQuery, setMentionQuery] = useState("");
-  const [selectedMentionIndex, setSelectedMentionIndex] = useState(-1); // Start with no selection
   const [isInsertingMention, setIsInsertingMention] = useState(false); // Flag to prevent reopening autocomplete after insertion
 
   const [attachedFiles, setAttachedFiles] = useState<AttachedFile[]>([]);
@@ -130,15 +129,10 @@ export function BaseMessageInput({
     insertMention,
     updateMentions,
     getMentionTags,
-    getFullTextWithPubkeys
+    getContentWithNpubs
   } = useUserMentions(message, setMessage, textareaRef);
 
-  // Enter key handler for mentions
-  const [mentionEnterHandler, setMentionEnterHandler] = useState<(() => boolean) | null>(null);
-
-  const handleMentionEnterKey = (handler: () => boolean) => {
-    setMentionEnterHandler(handler);
-  };
+  // No longer need separate Enter key handler
 
 
 
@@ -222,8 +216,8 @@ export function BaseMessageInput({
       let content = originalMessage;
       if (content) {
         content = replaceShortcodes(content);
-        // Convert display mentions to full mentions with pubkeys
-        content = getFullTextWithPubkeys(content);
+        // Convert display mentions to npub format
+        content = getContentWithNpubs(content);
       }
 
       // Add preview content (polls/events)
@@ -271,29 +265,7 @@ export function BaseMessageInput({
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    // If mention autocomplete is open, handle special keys
-    if (showMentionAutocomplete) {
-      switch (e.key) {
-        case 'Enter':
-        case 'Tab':
-          // Only call the handler if it exists and there are actual results to select from
-          if (mentionEnterHandler && mentionEnterHandler()) {
-            e.preventDefault();
-            return;
-          }
-          // For Tab key, always prevent default when autocomplete is open
-          if (e.key === 'Tab' && showMentionAutocomplete) {
-            e.preventDefault();
-            return;
-          }
-          break;
-        case 'Escape':
-          e.preventDefault();
-          setShowMentionAutocomplete(false);
-          setMentionQuery("");
-          return;
-      }
-    }
+    // Let the SimpleMentionTypeahead component handle its own keyboard events
 
     // If emoji autocomplete is open, handle navigation keys here
     if (showEmojiAutocomplete) {
@@ -322,7 +294,8 @@ export function BaseMessageInput({
       }
     }
 
-    if (e.key === "Enter" && !e.shiftKey) {
+    // Only handle Enter for submission if no autocomplete is open
+    if (e.key === "Enter" && !e.shiftKey && !showMentionAutocomplete && !showEmojiAutocomplete) {
       e.preventDefault();
       handleSubmit();
     }
@@ -373,9 +346,10 @@ export function BaseMessageInput({
     }, 0);
   };
 
-  const handleMentionSelect = (pubkey: string, displayName: string) => {
+  const handleMentionSelect = (npub: string, displayName: string) => {
     setIsInsertingMention(true);
-    insertMention(pubkey, displayName);
+    // Now we're receiving npub directly from the typeahead
+    insertMention(npub, displayName);
     setShowMentionAutocomplete(false);
     setMentionQuery("");
 
@@ -385,12 +359,7 @@ export function BaseMessageInput({
     }, 50);
   };
 
-  // Wrapper function to handle the type difference
-  const handleMentionKeyDown = (e: KeyboardEvent<Element>) => {
-    // Convert to React.KeyboardEvent for compatibility
-    const reactEvent = e as unknown as KeyboardEvent<HTMLTextAreaElement>;
-    handleKeyDown(reactEvent);
-  };
+  // No longer need separate key handler for mentions
 
   const updateAutocomplete = (newMessage: string, cursorPosition: number) => {
     const context = extractShortcodeContext(newMessage, cursorPosition);
@@ -440,7 +409,6 @@ export function BaseMessageInput({
         setShowMentionAutocomplete(true);
         const query = newMessage.slice(lastAtIndex + 1, textarea.selectionStart);
         setMentionQuery(query);
-        setSelectedMentionIndex(-1); // Start with no selection
       } else {
         setShowMentionAutocomplete(false);
         setMentionQuery("");
@@ -481,7 +449,6 @@ export function BaseMessageInput({
         setShowMentionAutocomplete(true);
         const query = message.slice(lastAtIndex + 1, textarea.selectionStart);
         setMentionQuery(query);
-        setSelectedMentionIndex(-1); // Start with no selection
       } else {
         setShowMentionAutocomplete(false);
         setMentionQuery("");
@@ -709,17 +676,12 @@ export function BaseMessageInput({
       </div>
 
       {showMentionAutocomplete && config.allowMentions && (
-        <UserMentionAutocomplete
+        <SimpleMentionTypeahead
           open={showMentionAutocomplete}
-          onOpenChange={setShowMentionAutocomplete}
+          onClose={() => setShowMentionAutocomplete(false)}
           query={mentionQuery}
           onSelect={handleMentionSelect}
           communityId={communityId}
-          triggerRef={textareaRef}
-          onKeyDown={handleMentionKeyDown}
-          selectedIndex={selectedMentionIndex}
-          onSelectedIndexChange={setSelectedMentionIndex}
-          onEnterKey={handleMentionEnterKey}
           rootMessage={rootMessage}
           threadReplies={threadReplies}
         />

--- a/src/hooks/useUserMentions.test.ts
+++ b/src/hooks/useUserMentions.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useUserMentions } from './useUserMentions';
-import { nip19 } from 'nostr-tools';
 
 describe('useUserMentions', () => {
   it('should detect mention query when typing @', () => {
@@ -48,31 +47,4 @@ describe('useUserMentions', () => {
     expect(tags).toEqual([]);
   });
 
-  it('should convert display text to content with npubs', () => {
-    const setText = vi.fn();
-    const textareaRef = { 
-      current: { 
-        selectionStart: 0, 
-        selectionEnd: 0, 
-        focus: vi.fn() 
-      } as unknown as HTMLTextAreaElement
-    };
-
-    const { result } = renderHook(() => useUserMentions('Hello @john', setText, textareaRef));
-
-    // Simulate inserting a mention
-    act(() => {
-      result.current.updateMentions('Hello @john', 11);
-    });
-
-    // Insert the mention
-    act(() => {
-      result.current.insertMention('1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef', 'John');
-    });
-
-    // Test conversion to npub format
-    const content = result.current.getContentWithNpubs('Hello @[John] how are you?');
-    const expectedNpub = nip19.npubEncode('1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef');
-    expect(content).toBe(`Hello ${expectedNpub} how are you?`);
-  });
 });

--- a/src/hooks/useUserMentions.ts
+++ b/src/hooks/useUserMentions.ts
@@ -32,12 +32,9 @@ export function useUserMentions(
   const [currentMention, setCurrentMention] = useState<{ query: string; startIndex: number } | null>(null);
   const [mentionMappings, setMentionMappings] = useState<MentionMapping[]>([]);
 
-  // This function is no longer needed since we're directly inserting npubs
-  // But we'll keep it for backward compatibility
-  const getContentWithNpubs = useCallback((text: string): string => {
-    // No need to replace anything since we're already using npubs directly
-    return text;
-  }, []);
+  // Simple pass-through function kept for API compatibility
+  // With our new approach, npubs are already directly inserted in the text
+  const getContentWithNpubs = useCallback((text: string): string => text, []);
 
   // Update mentions when text changes
   const updateMentions = useCallback((newText: string, cursorPosition: number) => {

--- a/src/hooks/useUserMentions.ts
+++ b/src/hooks/useUserMentions.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { nip19 } from 'nostr-tools';
 
 export interface MentionData {
   pubkey: string;
@@ -8,8 +9,7 @@ export interface MentionData {
 }
 
 interface MentionMapping {
-  displayText: string;
-  fullText: string;
+  npub: string;
   pubkey: string;
   displayName: string;
 }
@@ -20,7 +20,7 @@ export interface UseMentionsResult {
   insertMention: (pubkey: string, displayName: string) => void;
   updateMentions: (text: string, cursorPosition: number) => void;
   getMentionTags: () => string[][];
-  getFullTextWithPubkeys: (displayText: string) => string;
+  getContentWithNpubs: (text: string) => string;
 }
 
 export function useUserMentions(
@@ -32,89 +32,62 @@ export function useUserMentions(
   const [currentMention, setCurrentMention] = useState<{ query: string; startIndex: number } | null>(null);
   const [mentionMappings, setMentionMappings] = useState<MentionMapping[]>([]);
 
-  // Convert display text (with @[Name]) to full text (with @[Name](pubkey))
-  const getFullTextWithPubkeys = useCallback((displayText: string): string => {
-    let fullText = displayText;
-
-    // Replace each @[Name] with @[Name](pubkey) using our mappings
-    mentionMappings.forEach(mapping => {
-      fullText = fullText.replace(mapping.displayText, mapping.fullText);
-    });
-
-    return fullText;
-  }, [mentionMappings]);
-
-  // Convert full text (with pubkeys) to display text (without pubkeys)
-  const getDisplayText = useCallback((fullText: string): string => {
-    let displayText = fullText;
-
-    // Replace @[Name](pubkey) with @[Name]
-    const mentionRegex = /@\[([^\]]+)\]\(([^)]+)\)/g;
-    displayText = displayText.replace(mentionRegex, '@[$1]');
-
-    return displayText;
+  // This function is no longer needed since we're directly inserting npubs
+  // But we'll keep it for backward compatibility
+  const getContentWithNpubs = useCallback((text: string): string => {
+    // No need to replace anything since we're already using npubs directly
+    return text;
   }, []);
 
   // Update mentions when text changes
   const updateMentions = useCallback((newText: string, cursorPosition: number) => {
-    // Check if this is display text (without pubkeys) or full text (with pubkeys)
-    const hasFullMentions = /@\[([^\]]+)\]\(([^)]+)\)/.test(newText);
-
-    let workingText = newText;
     const foundMentions: MentionData[] = [];
     const newMappings: MentionMapping[] = [];
 
-    if (hasFullMentions) {
-      // This is full text with pubkeys - extract mentions and create mappings
-      const mentionRegex = /@\[([^\]]+)\]\(([^)]+)\)/g;
-      let match;
+    // Find npub patterns in the text
+    const npubRegex = /npub1[023456789acdefghjklmnpqrstuvwxyz]{58}/g;
+    let match;
 
-      while ((match = mentionRegex.exec(newText)) !== null) {
-        const displayName = match[1];
-        const pubkey = match[2];
-        const displayText = `@[${displayName}]`;
-        const fullText = match[0];
-
+    while ((match = npubRegex.exec(newText)) !== null) {
+      const npub = match[0];
+      
+      // Find corresponding mapping or create a new one
+      const mapping = mentionMappings.find(m => m.npub === npub);
+      
+      if (mapping) {
         foundMentions.push({
-          displayName,
-          pubkey,
+          displayName: mapping.displayName,
+          pubkey: mapping.pubkey,
           startIndex: match.index,
-          endIndex: match.index + match[0].length
+          endIndex: match.index + npub.length
         });
-
-        newMappings.push({
-          displayText,
-          fullText,
-          pubkey,
-          displayName
-        });
-      }
-
-      // Convert to display text for the UI
-      workingText = getDisplayText(newText);
-
-      // Update the text in the UI if it's different
-      if (workingText !== newText) {
-        setText(workingText);
-      }
-    } else {
-      // This is display text - find @[Name] patterns and match with existing mappings
-      const displayMentionRegex = /@\[([^\]]+)\]/g;
-      let match;
-
-      while ((match = displayMentionRegex.exec(workingText)) !== null) {
-        const displayName = match[1];
-
-        // Find corresponding mapping
-        const mapping = mentionMappings.find(m => m.displayName === displayName);
-        if (mapping) {
+        newMappings.push(mapping);
+      } else {
+        // Try to decode the npub to get the pubkey
+        try {
+          const decoded = nip19.decode(npub);
+          const pubkey = typeof decoded.data === 'string' 
+            ? decoded.data 
+            : 'unknown';
+          
+          // Create a new mapping with a generic display name
+          const displayName = "user";
+          const newMapping: MentionMapping = {
+            npub,
+            pubkey,
+            displayName
+          };
+          
           foundMentions.push({
             displayName,
-            pubkey: mapping.pubkey,
+            pubkey,
             startIndex: match.index,
-            endIndex: match.index + match[0].length
+            endIndex: match.index + npub.length
           });
-          newMappings.push(mapping);
+          
+          newMappings.push(newMapping);
+        } catch (e) {
+          console.error('Failed to decode npub:', e);
         }
       }
     }
@@ -151,29 +124,47 @@ export function useUserMentions(
     }
 
     setCurrentMention(null);
-  }, [mentionMappings, getDisplayText, setText]);
+  }, [mentionMappings]);
 
   // Insert a mention at the current position
-  const insertMention = useCallback((pubkey: string, displayName: string) => {
+  const insertMention = useCallback((npubOrPubkey: string, displayName: string) => {
     if (!currentMention || !textareaRef.current) return;
 
     const { startIndex } = currentMention;
     const textarea = textareaRef.current;
     const cursorPosition = textarea.selectionStart;
 
-    // Replace the @query with the display mention format
+    // Replace the @query with the npub directly
     // Note: startIndex includes the @ symbol, so we replace from startIndex
     const beforeMention = text.slice(0, startIndex);
     const afterMention = text.slice(cursorPosition);
-    const displayMentionText = `@[${displayName}]`; // Include @ in display text
-    const fullMentionText = `@[${displayName}](${pubkey})`;
-
-    const newDisplayText = beforeMention + displayMentionText + afterMention;
-
-    // Create new mapping
+    
+    // Determine if we received an npub or pubkey
+    let npub: string;
+    let pubkey: string;
+    
+    if (npubOrPubkey.startsWith('npub1')) {
+      // Already an npub
+      npub = npubOrPubkey;
+      try {
+        const decoded = nip19.decode(npub);
+        pubkey = decoded.data as string;
+      } catch (e) {
+        console.error('Failed to decode npub:', e);
+        pubkey = npubOrPubkey; // Fallback
+      }
+    } else {
+      // It's a pubkey, convert to npub
+      pubkey = npubOrPubkey;
+      npub = nip19.npubEncode(pubkey);
+    }
+    
+    // Insert the npub directly into the text
+    const newDisplayText = beforeMention + npub + afterMention;
+    
+    // Create a mapping for future reference
     const newMapping: MentionMapping = {
-      displayText: displayMentionText,
-      fullText: fullMentionText,
+      npub,
       pubkey,
       displayName
     };
@@ -184,8 +175,8 @@ export function useUserMentions(
     // Set the display text
     setText(newDisplayText);
 
-    // Set cursor position after the mention
-    const newCursorPosition = startIndex + displayMentionText.length;
+    // Set cursor position after the npub
+    const newCursorPosition = startIndex + npub.length;
 
     // Update cursor position after React re-renders
     setTimeout(() => {
@@ -201,12 +192,12 @@ export function useUserMentions(
     return mentions.map(mention => ['p', mention.pubkey]);
   }, [mentions]);
 
-  return {
+  return {  
     mentions,
     currentMention,
     insertMention,
     updateMentions,
     getMentionTags,
-    getFullTextWithPubkeys
+    getContentWithNpubs
   };
 }

--- a/src/hooks/useUserMentions.ts
+++ b/src/hooks/useUserMentions.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { nip19 } from 'nostr-tools';
+import { logger } from '@/lib/logger';
 
 export interface MentionData {
   pubkey: string;
@@ -84,7 +85,7 @@ export function useUserMentions(
           
           newMappings.push(newMapping);
         } catch (e) {
-          console.error('Failed to decode npub:', e);
+          logger.error('Failed to decode npub:', e);
         }
       }
     }
@@ -147,7 +148,7 @@ export function useUserMentions(
         const decoded = nip19.decode(npub);
         pubkey = decoded.data as string;
       } catch (e) {
-        console.error('Failed to decode npub:', e);
+        logger.error('Failed to decode npub:', e);
         pubkey = npubOrPubkey; // Fallback
       }
     } else {


### PR DESCRIPTION
close #108 

This PR changes tagging (by @name as before), to produce events with the said users npub.
I chose npub over nprofile thinking it's more standard (opinions welcome on this), and relay/pet data can generally be trivially derived by most clients.

A user types `@` to get a typeahead. As they type more characters, a shortlist is filtered.
This also fixes a bug with arrow/keyboard navigation of the typeahead.

<img width="359" height="335" alt="image" src="https://github.com/user-attachments/assets/5d98818e-9cf2-4a25-9a95-5057ff878e6c" />

On selecting a user, it injects their npub into the message input.

<img width="818" height="104" alt="image" src="https://github.com/user-attachments/assets/8c67fd56-9281-4a1e-9535-e67af8246992" />

When rendering this, however, I expanded existing markdown rendering, to swap in the - more readable - user name.

<img width="276" height="93" alt="image" src="https://github.com/user-attachments/assets/cb68d36f-80c9-4252-a747-0b2868c3e8b3" />

Lightmode too:

<img width="359" height="183" alt="image" src="https://github.com/user-attachments/assets/2619cb8d-20f1-4321-bd57-b28711fb023e" />


Thoughts:
- I was keen to show the raw message (with npub) when its being composed, so the user understands what they're going to send. However once published, we might want to let the user view a raw message. This is applicable for all our markdown rendering. A thought for later perhaps.
- This is just in channels (not DMs). Could make sense there, for aesthetics and consistency, although a user can't be tagged/notified that they were mentioned in someone elses DM, so becomes less relevant - Just a UX++ for those in the chat. So far in the code, user mentions was disabled for DMs.