### PR TITLE
Simplify notification badges, improve performance

### DIFF
--- a/src/app/components/EventActivity.svelte
+++ b/src/app/components/EventActivity.svelte
@@ -1,17 +1,18 @@
 <script lang="ts">
   import {onMount} from "svelte"
-  import {max, formatTimestampRelative} from "@welshman/lib"
+  import {max, gt, formatTimestampRelative} from "@welshman/lib"
   import {COMMENT} from "@welshman/util"
   import {load} from "@welshman/net"
   import {deriveArray, deriveEventsById} from "@welshman/store"
   import type {TrustedEvent} from "@welshman/util"
   import {repository} from "@welshman/app"
-  import {notifications} from "@app/util/notifications"
+  import {deriveChecked} from "@app/util/notifications"
   import Reply from "@assets/icons/reply-2.svg?dataurl"
   import Icon from "@lib/components/Icon.svelte"
 
   const {url, path, event}: {url: string; path: string; event: TrustedEvent} = $props()
 
+  const checked = deriveChecked(path)
   const filters = [{kinds: [COMMENT], "#E": [event.id]}]
   const replies = deriveArray(deriveEventsById({repository, filters}))
   const lastActive = $derived(max([...$replies, event].map(e => e.created_at)))
@@ -26,7 +27,7 @@
   <span>{$replies.length} {$replies.length === 1 ? "reply" : "replies"}</span>
 </div>
 <div class="btn btn-neutral btn-xs relative hidden rounded-full sm:flex">
-  {#if $notifications.has(path)}
+  {#if gt(lastActive, $checked)}
     <div class="h-2 w-2 rounded-full bg-primary"></div>
   {/if}
   Active {formatTimestampRelative(lastActive)}

--- a/src/app/components/SpaceMenu.svelte
+++ b/src/app/components/SpaceMenu.svelte
@@ -55,7 +55,6 @@
     displayRoom,
   } from "@app/core/state"
   import {setSpaceNotifications} from "@app/core/commands"
-  import {notifications} from "@app/util/notifications"
   import {pushModal} from "@app/util/modal"
   import {makeSpacePath, makeChatPath} from "@app/util/routes"
 
@@ -227,42 +226,27 @@
           <Icon icon={History} /> Recent Activity
         </SecondaryNavItem>
       {:else}
-        <SecondaryNavItem
-          {replaceState}
-          href={chatPath}
-          notification={$notifications.has(chatPath)}>
+        <SecondaryNavItem {replaceState} href={chatPath}>
           <Icon icon={ChatRound} /> Chat
         </SecondaryNavItem>
       {/if}
       {#if ENABLE_ZAPS && $spaceKinds.has(ZAP_GOAL)}
-        <SecondaryNavItem
-          {replaceState}
-          href={goalsPath}
-          notification={$notifications.has(goalsPath)}>
+        <SecondaryNavItem {replaceState} href={goalsPath}>
           <Icon icon={StarFallMinimalistic} /> Goals
         </SecondaryNavItem>
       {/if}
       {#if $spaceKinds.has(THREAD)}
-        <SecondaryNavItem
-          {replaceState}
-          href={threadsPath}
-          notification={$notifications.has(threadsPath)}>
+        <SecondaryNavItem {replaceState} href={threadsPath}>
           <Icon icon={NotesMinimalistic} /> Threads
         </SecondaryNavItem>
       {/if}
       {#if $spaceKinds.has(CLASSIFIED)}
-        <SecondaryNavItem
-          {replaceState}
-          href={classifiedsPath}
-          notification={$notifications.has(classifiedsPath)}>
+        <SecondaryNavItem {replaceState} href={classifiedsPath}>
           <Icon icon={CaseMinimalistic} /> Classifieds
         </SecondaryNavItem>
       {/if}
       {#if $spaceKinds.has(EVENT_TIME)}
-        <SecondaryNavItem
-          {replaceState}
-          href={calendarPath}
-          notification={$notifications.has(calendarPath)}>
+        <SecondaryNavItem {replaceState} href={calendarPath}>
           <Icon icon={CalendarMinimalistic} /> Calendar
         </SecondaryNavItem>
       {/if}
@@ -272,7 +256,7 @@
           <SecondaryNavHeader>Your Rooms</SecondaryNavHeader>
         {/if}
         {#each $userRooms as h, i (h)}
-          <SpaceMenuRoomItem {replaceState} notify {url} {h} />
+          <SpaceMenuRoomItem {replaceState} {url} {h} />
         {/each}
         {#if $otherRooms.length > 0}
           <div class="h-2"></div>

--- a/src/app/components/SpaceMenuButton.svelte
+++ b/src/app/components/SpaceMenuButton.svelte
@@ -3,14 +3,10 @@
   import Icon from "@lib/components/Icon.svelte"
   import Button from "@lib/components/Button.svelte"
   import SpaceMenu from "@app/components/SpaceMenu.svelte"
-  import {notifications} from "@app/util/notifications"
-  import {makeSpacePath} from "@app/util/routes"
   import {pushDrawer} from "@app/util/modal"
   import {deriveSocketStatus} from "@app/core/state"
 
   const {url} = $props()
-
-  const path = makeSpacePath(url) + ":mobile"
 
   const status = deriveSocketStatus(url)
 
@@ -21,7 +17,5 @@
   <Icon icon={MenuDots} />
   {#if $status.theme !== "success"}
     <div class="absolute right-0 top-0 -mr-1 -mt-1 h-2 w-2 rounded-full bg-{$status.theme}"></div>
-  {:else if $notifications.has(path)}
-    <div class="absolute right-0 top-0 -mr-1 -mt-1 h-2 w-2 rounded-full bg-primary"></div>
   {/if}
 </Button>

--- a/src/app/components/SpaceMenuRoomItem.svelte
+++ b/src/app/components/SpaceMenuRoomItem.svelte
@@ -5,17 +5,15 @@
   import SecondaryNavItem from "@lib/components/SecondaryNavItem.svelte"
   import RoomNameWithImage from "@app/components/RoomNameWithImage.svelte"
   import {makeRoomPath} from "@app/util/routes"
-  import {notifications} from "@app/util/notifications"
   import {deriveShouldNotify} from "@app/core/state"
 
   interface Props {
     url: any
     h: any
-    notify?: boolean
     replaceState?: boolean
   }
 
-  const {url, h, notify = false, replaceState = false}: Props = $props()
+  const {url, h, replaceState = false}: Props = $props()
 
   const path = makeRoomPath(url, h)
   const shouldNotifyForSpace = deriveShouldNotify(url)
@@ -23,10 +21,7 @@
   const showDifferenceIcon = $derived($shouldNotifyForRoom !== $shouldNotifyForSpace)
 </script>
 
-<SecondaryNavItem
-  href={path}
-  {replaceState}
-  notification={notify ? $notifications.has(path) : false}>
+<SecondaryNavItem href={path} {replaceState}>
   <RoomNameWithImage {url} {h} />
   {#if showDifferenceIcon}
     <Icon icon={$shouldNotifyForRoom ? VolumeLoud : VolumeCross} size={4} class="opacity-50" />

--- a/src/app/core/state.ts
+++ b/src/app/core/state.ts
@@ -49,6 +49,7 @@ import {
   makeLoadItem,
   makeDeriveItem,
   deriveItemsByKey,
+  deriveDeduplicated,
   deriveEventsByIdByUrl,
   deriveEventsByIdForUrl,
   getEventsByIdForUrl,
@@ -99,6 +100,7 @@ import {
   readRoomMeta,
   makeRoomMeta,
   ManagementMethod,
+  sortEventsDesc,
 } from "@welshman/util"
 import type {TrustedEvent, RelayProfile, PublishedRoomMeta, List, Filter} from "@welshman/util"
 import {routerContext, Router} from "@welshman/router"
@@ -227,13 +229,18 @@ export const deriveEvent = makeDeriveEvent({
   onDerive: (filters: Filter[], relays: string[]) => load({filters, relays}),
 })
 
-export const getEventsForUrl = (url: string, filters: Filter[]) =>
+export const getEventsForUrl = (url: string, filters: Filter[] = [{}]) =>
   getEventsByIdForUrl({url, tracker, repository, filters}).values()
 
-export const deriveEventsForUrl = (url: string, filters: Filter[]) =>
+export const deriveEventsForUrl = (url: string, filters: Filter[] = [{}]) =>
   deriveArray(deriveEventsByIdForUrl({url, tracker, repository, filters}))
 
-export const deriveRelaySignedEvents = (url: string, filters: Filter[]) =>
+export const deriveLatestEventForUrl = (url: string, filters: Filter[] = [{}]) =>
+  deriveDeduplicated(deriveEventsByIdForUrl({url, tracker, repository, filters}), $eventsById =>
+    first(sortEventsDesc($eventsById.values())),
+  )
+
+export const deriveRelaySignedEvents = (url: string, filters: Filter[] = [{}]) =>
   derived(
     [deriveRelay(url), deriveEventsForUrl(url, filters)],
     ([relay, events]) => events,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -142,11 +142,14 @@
     // History, navigation, application data
     unsubscribers.push(setupHistory(), setupAnalytics(), syncApplicationData())
 
-    // Subscribe to badge count for changes
-    unsubscribers.push(notifications.syncBadges)
-
     // Initialize keyboard state tracking
     unsubscribers.push(syncKeyboard())
+
+    // Subscribe to badge count for changes
+    unsubscribers.push(notifications.syncBadges())
+
+    // Subscribe to page history to update checked state
+    unsubscribers.push(notifications.syncChecked())
 
     // Initialize background notifications
     unsubscribers.push(notifications.Push.sync())

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import {page} from "$app/stores"
-  import {onDestroy} from "svelte"
   import InfoCircle from "@assets/icons/info-circle.svg?dataurl"
   import Magnifier from "@assets/icons/magnifier.svg?dataurl"
   import MenuDots from "@assets/icons/menu-dots.svg?dataurl"
@@ -13,7 +11,6 @@
   import ChatMenu from "@app/components/ChatMenu.svelte"
   import {chatSearch} from "@app/core/state"
   import {pushModal} from "@app/util/modal"
-  import {setChecked} from "@app/util/notifications"
 
   let term = $state("")
 
@@ -22,10 +19,6 @@
   const openMenu = () => pushModal(ChatMenu)
 
   const chats = $derived($chatSearch.searchOptions(term))
-
-  onDestroy(() => {
-    setChecked($page.url.pathname)
-  })
 </script>
 
 <div class="hidden min-h-screen md:hero">

--- a/src/routes/chat/[chat]/+page.svelte
+++ b/src/routes/chat/[chat]/+page.svelte
@@ -4,18 +4,10 @@
   import {append, uniq} from "@welshman/lib"
   import {pubkey} from "@welshman/app"
   import Chat from "@app/components/Chat.svelte"
-  import {notifications, setChecked} from "@app/util/notifications"
   import {splitChatId} from "@app/core/state"
 
   const {chat} = $page.params as MakeNonOptional<typeof $page.params>
   const pubkeys = uniq(append($pubkey!, splitChatId(chat)))
-
-  // We have to watch this one, since on mobile the badge will be visible when active
-  $effect(() => {
-    if ($notifications.has($page.url.pathname)) {
-      setChecked($page.url.pathname)
-    }
-  })
 </script>
 
 <Chat {pubkeys} />

--- a/src/routes/spaces/[relay]/+layout.svelte
+++ b/src/routes/spaces/[relay]/+layout.svelte
@@ -8,10 +8,8 @@
   import SpaceAuthError from "@app/components/SpaceAuthError.svelte"
   import SpaceTrustRelay from "@app/components/SpaceTrustRelay.svelte"
   import {pushModal} from "@app/util/modal"
-  import {setChecked} from "@app/util/notifications"
   import {decodeRelay, relaysPendingTrust} from "@app/core/state"
   import {deriveRelayAuthError} from "@app/core/commands"
-  import {notifications} from "@app/util/notifications"
 
   type Props = {
     children?: Snippet
@@ -28,13 +26,6 @@
   )
 
   const showPendingTrust = once(() => pushModal(SpaceTrustRelay, {url}, {noEscape: true}))
-
-  // We have to watch this one, since on mobile the badge will be visible when active
-  $effect(() => {
-    if ($notifications.has($page.url.pathname)) {
-      setChecked($page.url.pathname)
-    }
-  })
 
   // Watch for relay errors and notify the user
   $effect(() => {

--- a/src/routes/spaces/[relay]/[h]/+page.svelte
+++ b/src/routes/spaces/[relay]/[h]/+page.svelte
@@ -45,7 +45,7 @@
     MESSAGE_KINDS,
     userSettingsValues,
   } from "@app/core/state"
-  import {setChecked, checked} from "@app/util/notifications"
+  import {checked} from "@app/util/notifications"
   import {canEnforceNip70, prependParent, publishDelete} from "@app/core/commands"
   import {makeFeed} from "@app/core/requests"
   import {popKey} from "@lib/implicit"
@@ -318,11 +318,6 @@
 
   onDestroy(() => {
     cleanup?.()
-
-    // Sveltekit calls onDestroy at the beginning of the page load for some reason
-    setTimeout(() => {
-      setChecked($page.url.pathname)
-    }, 800)
   })
 </script>
 

--- a/src/routes/spaces/[relay]/calendar/+page.svelte
+++ b/src/routes/spaces/[relay]/calendar/+page.svelte
@@ -21,7 +21,6 @@
   import {pushModal} from "@app/util/modal"
   import {decodeRelay, makeCommentFilter} from "@app/core/state"
   import {makeCalendarFeed} from "@app/core/requests"
-  import {setChecked} from "@app/util/notifications"
 
   const url = decodeRelay($page.params.relay!)
 
@@ -108,7 +107,6 @@
 
     return () => {
       feed.cleanup()
-      setChecked($page.url.pathname)
     }
   })
 </script>

--- a/src/routes/spaces/[relay]/calendar/[address]/+page.svelte
+++ b/src/routes/spaces/[relay]/calendar/[address]/+page.svelte
@@ -25,7 +25,6 @@
   import CalendarEventDate from "@app/components/CalendarEventDate.svelte"
   import EventReply from "@app/components/EventReply.svelte"
   import {deriveEvent, decodeRelay} from "@app/core/state"
-  import {setChecked} from "@app/util/notifications"
 
   const {relay, address} = $page.params as MakeNonOptional<typeof $page.params>
   const url = decodeRelay(relay)
@@ -57,7 +56,6 @@
 
     return () => {
       controller.abort()
-      setChecked($page.url.pathname)
     }
   })
 </script>

--- a/src/routes/spaces/[relay]/classifieds/+page.svelte
+++ b/src/routes/spaces/[relay]/classifieds/+page.svelte
@@ -17,7 +17,6 @@
   import ClassifiedItem from "@app/components/ClassifiedItem.svelte"
   import ClassifiedCreate from "@app/components/ClassifiedCreate.svelte"
   import {decodeRelay} from "@app/core/state"
-  import {setChecked} from "@app/util/notifications"
   import {makeCommentFilter} from "@app/core/state"
   import {makeFeed} from "@app/core/requests"
   import {pushModal} from "@app/util/modal"
@@ -59,7 +58,6 @@
 
     return () => {
       feed.cleanup()
-      setChecked($page.url.pathname)
     }
   })
 </script>

--- a/src/routes/spaces/[relay]/classifieds/[address]/+page.svelte
+++ b/src/routes/spaces/[relay]/classifieds/[address]/+page.svelte
@@ -22,7 +22,6 @@
   import CommentActions from "@app/components/CommentActions.svelte"
   import EventReply from "@app/components/EventReply.svelte"
   import {deriveEvent, decodeRelay} from "@app/core/state"
-  import {setChecked} from "@app/util/notifications"
 
   const {relay, address} = $page.params as MakeNonOptional<typeof $page.params>
   const url = decodeRelay(relay)
@@ -54,7 +53,6 @@
 
     return () => {
       controller.abort()
-      setChecked($page.url.pathname)
     }
   })
 </script>

--- a/src/routes/spaces/[relay]/goals/+page.svelte
+++ b/src/routes/spaces/[relay]/goals/+page.svelte
@@ -17,7 +17,6 @@
   import GoalItem from "@app/components/GoalItem.svelte"
   import GoalCreate from "@app/components/GoalCreate.svelte"
   import {decodeRelay, makeCommentFilter} from "@app/core/state"
-  import {setChecked} from "@app/util/notifications"
   import {makeFeed} from "@app/core/requests"
   import {pushModal} from "@app/util/modal"
 
@@ -58,7 +57,6 @@
 
     return () => {
       feed.cleanup()
-      setChecked($page.url.pathname)
     }
   })
 </script>

--- a/src/routes/spaces/[relay]/goals/[id]/+page.svelte
+++ b/src/routes/spaces/[relay]/goals/[id]/+page.svelte
@@ -22,7 +22,6 @@
   import CommentActions from "@app/components/CommentActions.svelte"
   import EventReply from "@app/components/EventReply.svelte"
   import {deriveEvent, decodeRelay} from "@app/core/state"
-  import {setChecked} from "@app/util/notifications"
 
   const {relay, id} = $page.params as MakeNonOptional<typeof $page.params>
   const url = decodeRelay(relay)
@@ -55,7 +54,6 @@
 
     return () => {
       controller.abort()
-      setChecked($page.url.pathname)
     }
   })
 </script>

--- a/src/routes/spaces/[relay]/threads/+page.svelte
+++ b/src/routes/spaces/[relay]/threads/+page.svelte
@@ -17,7 +17,6 @@
   import ThreadItem from "@app/components/ThreadItem.svelte"
   import ThreadCreate from "@app/components/ThreadCreate.svelte"
   import {decodeRelay} from "@app/core/state"
-  import {setChecked} from "@app/util/notifications"
   import {makeCommentFilter} from "@app/core/state"
   import {makeFeed} from "@app/core/requests"
   import {pushModal} from "@app/util/modal"
@@ -59,7 +58,6 @@
 
     return () => {
       feed.cleanup()
-      setChecked($page.url.pathname)
     }
   })
 </script>

--- a/src/routes/spaces/[relay]/threads/[id]/+page.svelte
+++ b/src/routes/spaces/[relay]/threads/[id]/+page.svelte
@@ -22,7 +22,6 @@
   import CommentActions from "@app/components/CommentActions.svelte"
   import EventReply from "@app/components/EventReply.svelte"
   import {deriveEvent, decodeRelay} from "@app/core/state"
-  import {setChecked} from "@app/util/notifications"
 
   const {relay, id} = $page.params as MakeNonOptional<typeof $page.params>
   const url = decodeRelay(relay)
@@ -54,7 +53,6 @@
 
     return () => {
       controller.abort()
-      setChecked($page.url.pathname)
     }
   })
 </script>


### PR DESCRIPTION
This was a refactor since notifications are always a little flaky — phantom dots, sounds, etc. This should help. Main changes:

- Centralize logic for updating the checked store
- Remove stuff related to specific rooms/content types, space-level should be enough

